### PR TITLE
Allow marketplace bot installation without explicit persona ID

### DIFF
--- a/flexus_client_kit/ckit_bot_install.py
+++ b/flexus_client_kit/ckit_bot_install.py
@@ -120,25 +120,25 @@ async def marketplace_upsert_dev_bot(
 async def bot_install_from_marketplace(
     client: ckit_client.FlexusClient,
     ws_id: str,
+    inside_fgroup: Optional[str],
     persona_marketable_name: str,
-    persona_id: str,
     persona_name: str,
     new_setup: Dict[str, Union[str, int, bool]],
-    inside_fgroup: Optional[str] = None,
-    specific_version: Optional[int] = None,
     install_dev_version: bool = False,
+    persona_id: Optional[str] = None,
+    specific_version: Optional[int] = None,
 ) -> InstallationResult:
     http = await client.use_http()
     async with http as h:
         r = await h.execute(
-            gql.gql("""mutation PersonaUpsert($ws: String!, $g: String, $mn: String!, $id: String!, $name: String!, $setup: String!, $v: Int, $dev: Boolean!) {
+            gql.gql("""mutation PersonaUpsert($ws: String!, $g: String, $mn: String!, $id: String, $name: String!, $setup: String!, $v: Int, $dev: Boolean!) {
                 bot_install_from_marketplace(
                     ws_id: $ws,
                     inside_fgroup_id: $g,
                     persona_marketable_name: $mn,
                     persona_id: $id,
                     persona_name: $name,
-                    new_setup: $setup
+                    new_setup: $setup,
                     specific_version: $v,
                     install_dev_version: $dev,
                 ) {

--- a/flexus_simple_bots/karen/karen_scenario_captured_thread.py
+++ b/flexus_simple_bots/karen/karen_scenario_captured_thread.py
@@ -68,14 +68,11 @@ async def setup_test(client: ckit_client.FlexusClient) -> tuple[str, str, str]:
             }
         )
     mcp_id = mcp_resp["mcp_server_create"]["mcp_id"]
-
-    persona_id = str(uuid.uuid4())[:8]
-    await ckit_bot_install.bot_install_from_marketplace(
+    install_result = await ckit_bot_install.bot_install_from_marketplace(
         client,
         ws_id=ws_id,
         inside_fgroup=test_group_id,
         persona_marketable_name="karen",
-        persona_id=persona_id,
         persona_name="Karen AWS Docs Test",
         new_setup={
             "SLACK_BOT_TOKEN": "fake_bot_token",
@@ -85,7 +82,7 @@ async def setup_test(client: ckit_client.FlexusClient) -> tuple[str, str, str]:
         install_dev_version=True,
     )
 
-    return test_group_id, persona_id, mcp_id
+    return test_group_id, install_result.persona_id, mcp_id
 
 
 async def _cleanup(client: ckit_client.FlexusClient, persona_id: str, group_id: str, mcp_id: str) -> None:

--- a/flexus_simple_bots/karen/karen_scenario_prioritize2.py
+++ b/flexus_simple_bots/karen/karen_scenario_prioritize2.py
@@ -10,7 +10,7 @@ async def init(client: ckit_client.FlexusClient, ws_id: str, fgroup_id: str, per
     await ckit_bot_install.bot_install_from_marketplace(
         client,
         ws_id=ws_id,
-        inside_fgroup_id=fgroup_id,
+        inside_fgroup=fgroup_id,
         persona_marketable_name=karen_bot.BOT_NAME,
         persona_id=persona_id,
         persona_name="Karen Superbot 3",


### PR DESCRIPTION
## Summary
- Support installing a marketplace bot without specifying a persona ID and let the server generate it
- Update Karen captured-thread scenario to rely on the backend-provided persona ID
- Reorder marketplace installation parameters so optional persona ID follows required arguments

## Testing
- ✅ `pip install pytest-asyncio`
- ⚠️ `pytest -q` *(skipped: 8)*

------
https://chatgpt.com/codex/tasks/task_e_68c7f799251c832f9050736ee8753f7e