### PR TITLE
Use configured bot name in Karen captured thread scenario

### DIFF
--- a/flexus_simple_bots/karen/karen_bot.py
+++ b/flexus_simple_bots/karen/karen_bot.py
@@ -20,6 +20,7 @@ logger = logging.getLogger("bot_karen")
 BOT_NAME = "karen"
 BOT_VERSION = "0.1.14"
 BOT_VERSION_INT = ckit_client.marketplace_version_as_int(BOT_VERSION)
+KAREN_NAME = f"{BOT_NAME}_test"
 
 
 FILE_JIRA_TOOL = ckit_cloudtool.CloudTool(

--- a/flexus_simple_bots/karen/karen_scenario_captured_thread.py
+++ b/flexus_simple_bots/karen/karen_scenario_captured_thread.py
@@ -110,7 +110,7 @@ async def run_scenario() -> None:
     bot_task = None
     try:
         bot_client = ckit_client.FlexusClient(
-            f"karen_test_{karen_bot.BOT_VERSION_INT}_{test_group_id}",
+            ckit_client.bot_service_name(karen_bot.KAREN_NAME, karen_bot.BOT_VERSION_INT, test_group_id),
             endpoint="/v1/jailed-bot"
         )
 


### PR DESCRIPTION
## Summary
- add KAREN_NAME constant to Karen bot
- build captured thread scenario bot service name from KAREN_NAME

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c7f8c702f0832f9d86aa3ad63049a8