### PR TITLE
sergei-fixes-11

### DIFF
--- a/flexus_client_kit/format_utils.py
+++ b/flexus_client_kit/format_utils.py
@@ -113,7 +113,7 @@ def format_json_output(
 def format_text_output(
     path: str,
     content: str,
-    lines_range: str,
+    lines_range: str = ":",
     safety_valve: str = DEFAULT_SAFETY_VALVE
 ) -> str:
     # Please leave this function alone -- Oleg
@@ -161,7 +161,7 @@ def format_text_output(
 def format_binary_output(
     path: str,
     data: bytes,
-    lines_range: str,
+    lines_range: str = ":",
     safety_valve: str = DEFAULT_SAFETY_VALVE
 ) -> str:
     """Format binary data for display, with special handling for images."""
@@ -213,7 +213,7 @@ def format_binary_output(
 def format_cat_output(
     path: str,
     file_data: Union[bytes, str, list, dict],
-    lines_range: str,
+    lines_range: str = ":",
     safety_valve: str = DEFAULT_SAFETY_VALVE
 ) -> str:
     """Main function to format file data for display."""


### PR DESCRIPTION
Add report removal tool, fix section check, and adjust file storage paths

- Introduce REMOVE_REPORT_TOOL and handle_remove_report_tool to delete a report and its associated files (JSON, HTML, metadata) with clear feedback and listing of remaining reports.
- Wire the tool into adspy bot and bump BOT_VERSION to 0.6.6.
- Prevent duplicate report creation by checking for existing report ID.
- Correct section filled check in fill_section to use membership test on sections.
- Default lines_range to ":" in format_utils formatters to simplify callers.
- Store files in Mongo without the "output/" prefix in Python executor to keep consistent paths.