### PR TITLE
add owner_fuser_id to FExternalDataSourceOutput

### DIFF
--- a/flexus_client_kit/ckit_edoc.py
+++ b/flexus_client_kit/ckit_edoc.py
@@ -9,6 +9,7 @@ logger = logging.getLogger("edocs")
 
 @dataclass
 class FExternalDataSourceOutput:
+    owner_fuser_id: str
     located_fgroup_id: str
     eds_id: str
     eds_name: str


### PR DESCRIPTION
-- why?
Need to return owner to be able to fetch their external key later when scanning eds