### PR TITLE
rename eds_last_scan_ts and consistent FEdoc prefix

### DIFF
--- a/flexus_client_kit/ckit_edoc.py
+++ b/flexus_client_kit/ckit_edoc.py
@@ -25,15 +25,6 @@ class FExternalDataSourceSubs:
     news_payload: Optional[FExternalDataSourceOutput]
 
 @dataclass
-class FEphemeralDocumentOutput:
-    edoc_id: str
-    edoc_mtime: int
-    edoc_size_bytes: int
-    edoc_status_download: str
-    edoc_status_graphdb: str
-    edoc_status_vectordb: str
-
-@dataclass
 class FEdocOutput:
     ws_id: str
     eds_id: str


### PR DESCRIPTION
-- why?
- last "successful" scan is not much useful for tool reporting scan errors.
- remove duplicate FEdocOutput

Merge together with [flexus-1175](https://github.com/smallcloudai/flexus/pull/1175)