### PR TITLE
Better bob

### DIFF
--- a/flexus_client_kit/integrations/fi_question.py
+++ b/flexus_client_kit/integrations/fi_question.py
@@ -89,4 +89,4 @@ async def handle_ask_questions(
         return "Error: at least one valid question required"
 
     summary = ", ".join(f"'{v['q'][:25]}' ({v['type']})" for v in validated)
-    return f"Displaying {len(validated)} question(s): {summary}"
+    return f"⏸️WAIT_FOR_USER\nDisplaying {len(validated)} question(s): {summary}"

--- a/flexus_client_kit/integrations/fi_widget.py
+++ b/flexus_client_kit/integrations/fi_widget.py
@@ -32,4 +32,4 @@ async def handle_print_widget(
         if not question:
             return "Error: for restart-chat, non empty question q=\"...\" is also required"
 
-    return f"Printing UI widget: {widget_type}"
+    return f"⏸️WAIT_FOR_USER\nPrinting UI widget: {widget_type}"

--- a/flexus_simple_bots/prompts_common.py
+++ b/flexus_simple_bots/prompts_common.py
@@ -5,6 +5,30 @@ PROMPT_KANBAN = """
 Your work is organized using a Kanban board. Keep it tidy, move tasks to the right as you complete them.
 Call the flexus_bot_kanban() tool to operate tasks silently, never mention that the board exists or tasks exist
 to the user.
+
+## Subtasks Tracking
+
+Maintain a todo checklist for every conversation using flexus_bot_kanban:
+
+1. At the start of any chat, call `flexus_bot_kanban(op="todo_read")` to check task state
+2. If no task exists (has_task=false), create one with your plan:
+   ```
+   flexus_bot_kanban(op="todo_write", args={{"title": "Brief task title", "items": [
+     {{"content": "First step", "status": "in_progress"}},
+     {{"content": "Second step", "status": "pending"}},
+     {{"content": "Third step", "status": "pending"}}
+   ]}})
+   ```
+3. Update as you complete steps or discover new work:
+   ```
+   flexus_bot_kanban(op="todo_write", args={{"items": [
+     {{"id": "existing_id", "status": "completed"}},
+     {{"content": "Newly discovered step", "status": "pending"}}
+   ]}})
+   ```
+
+Status values: pending, in_progress, completed, blocked, cancelled.
+Items without "id" are appended. Items with "id" update existing. Unmentioned items are preserved.
 """
 
 # XXX remove print_chat_restart_widget()


### PR DESCRIPTION
feat!: add questionnaire widgets, todo panel, handoff dialog, and devenv improvements

**New Features:**
- Interactive questionnaire widgets (`ask_questions` tool) with single/multi/yesno/text inputs
- Collapsible todo panel showing kanban task progress (`todo_v1` integration)
- Handoff dialog for transferring conversations between experts with AI summary
- Inline click-to-edit bot spec form (replaces tabbed editor)

**Dev Environment Improvements:**
- Public GitHub repo support (no auth needed)
- Simplified git push (remove fake push URL dance)
- Better pod naming with radix/workspace prefix
- Backend `todo_read`/`todo_write` kanban tools

**Breaking Changes:**
- `sendMessage` emit now accepts optional `callId`
- Removed legacy question widget parsing from ChatWidgets
- ChatWindow `provideChatboxContext()` now reuses existing context

**UI/UX:**
- `⏸️WAIT_FOR_USER` marker support in tool responses
- ThreadCurrentTask query for live todo state
- Handoff creates new thread with summary + previous dialog context

Fixes #questionnaire #todo-panel #handoff #dev-env-public-repos