### PR TITLE
feat(fi_question): add structured questions API with backward compati…

### DIFF
--- a/flexus_client_kit/integrations/fi_question.py
+++ b/flexus_client_kit/integrations/fi_question.py
@@ -7,32 +7,33 @@ ASK_QUESTIONS_TOOL = ckit_cloudtool.CloudTool(
     name="ask_questions",
     description="""Ask the user one or more questions with interactive UI. Use this instead of numbered lists.
 
-Format: "question text | type | option1; option2; ..."
-
-Types:
-- "single": pick one option
-- "multi": pick multiple options
-- "text": free-form input (no options needed)
-- "yesno": yes/no buttons (no options needed)
+Types: "single" (pick one), "multi" (pick several), "text" (free-form), "yesno" (yes/no buttons).
 
 Example:
-ask_questions(
-    q1="What kind of bot do you want? | single | Support; Sales; Analytics; Other",
-    q2="Which channels should it support? | multi | Slack; Email; Discord; Telegram",
-    q3="Should it run on a schedule? | yesno",
-    q4="Any special requirements? | text"
-)""",
+ask_questions(questions=[
+    {"text": "What kind of bot do you want?", "type": "single", "options": ["Support", "Sales", "Analytics", "Other"]},
+    {"text": "Which channels should it support?", "type": "multi", "options": ["Slack", "Email", "Discord", "Telegram"]},
+    {"text": "Should it run on a schedule?", "type": "yesno"},
+    {"text": "Any special requirements?", "type": "text"}
+])""",
     parameters={
         "type": "object",
         "properties": {
-            "q1": {"type": "string", "description": "First question: 'text | type | options'"},
-            "q2": {"type": "string", "description": "Second question (optional)"},
-            "q3": {"type": "string", "description": "Third question (optional)"},
-            "q4": {"type": "string", "description": "Fourth question (optional)"},
-            "q5": {"type": "string", "description": "Fifth question (optional)"},
-            "q6": {"type": "string", "description": "Sixth question (optional)"},
+            "questions": {
+                "type": "array",
+                "description": "List of questions to ask",
+                "items": {
+                    "type": "object",
+                    "properties": {
+                        "text": {"type": "string", "description": "The question text"},
+                        "type": {"type": "string", "enum": ["single", "multi", "text", "yesno"]},
+                        "options": {"type": "array", "items": {"type": "string"}, "description": "Options for single/multi"},
+                    },
+                    "required": ["text", "type"],
+                },
+            },
         },
-        "required": ["q1"],
+        "required": ["questions"],
         "additionalProperties": False,
     },
 )
@@ -42,15 +43,13 @@ MAX_OPTIONS = 20
 MAX_TEXT_LEN = 500
 
 
-def parse_question(q_str: str) -> Optional[Dict[str, Any]]:
-    # Split on first | to get question
+def _parse_legacy_question(q_str: str) -> Optional[Dict[str, Any]]:
     head, sep, rest = q_str.partition("|")
     if not sep:
         return None
     question = head.strip()
     if not question:
         return None
-    # Split remainder on first | to get type and options
     type_part, sep2, opts_part = rest.partition("|")
     qtype = type_part.strip().lower()
     if qtype not in ["single", "multi", "text", "yesno"]:
@@ -58,7 +57,30 @@ def parse_question(q_str: str) -> Optional[Dict[str, Any]]:
     options = None
     if sep2 and opts_part.strip():
         options = [o.strip() for o in opts_part.split(";") if o.strip()]
+        if not options:
+            options = [o.strip() for o in opts_part.split(",") if o.strip()]
     return {"q": question, "type": qtype, "options": options}
+
+
+def _validate_questions(raw: List[Dict[str, Any]]) -> tuple:
+    validated: List[Dict[str, Any]] = []
+    for i, item in enumerate(raw[:MAX_QUESTIONS]):
+        q = item.get("q", "")
+        qtype = item.get("type", "")
+        options = item.get("options")
+        if not q or qtype not in ["single", "multi", "text", "yesno"]:
+            return None, f"Error: question {i+1} invalid"
+        if len(q) > MAX_TEXT_LEN:
+            return None, f"Error: question {i+1} text too long"
+        if qtype in ["single", "multi"]:
+            if not options:
+                return None, f"Error: question {i+1} ({qtype}) requires options"
+            if len(options) > MAX_OPTIONS:
+                return None, f"Error: question {i+1} too many options"
+        validated.append({"q": q, "type": qtype, "options": options})
+    if not validated:
+        return None, "Error: at least one valid question required"
+    return validated, None
 
 
 async def handle_ask_questions(
@@ -66,27 +88,28 @@ async def handle_ask_questions(
     model_produced_args: Optional[Dict[str, Any]],
 ) -> str:
     if not model_produced_args:
-        return "Error: at least q1 is required"
+        return "Error: questions array is required"
 
-    validated: List[Dict[str, Any]] = []
-    for i in range(1, MAX_QUESTIONS + 1):
-        q_str = model_produced_args.get(f"q{i}")
-        if not q_str or not isinstance(q_str, str):
-            continue
-        parsed = parse_question(q_str)
-        if not parsed:
-            return f"Error: q{i} invalid format. Use 'question | type | options'"
-        if len(parsed["q"]) > MAX_TEXT_LEN:
-            return f"Error: q{i} text too long"
-        if parsed["type"] in ["single", "multi"]:
-            if not parsed["options"]:
-                return f"Error: q{i} ({parsed['type']}) requires options"
-            if len(parsed["options"]) > MAX_OPTIONS:
-                return f"Error: q{i} too many options"
-        validated.append(parsed)
+    raw: List[Dict[str, Any]] = []
+    if "questions" in model_produced_args and isinstance(model_produced_args["questions"], list):
+        for item in model_produced_args["questions"]:
+            if not isinstance(item, dict):
+                continue
+            raw.append({"q": item.get("text", ""), "type": item.get("type", ""), "options": item.get("options")})
+    else:
+        # legacy q1..q6 string format
+        for i in range(1, MAX_QUESTIONS + 1):
+            q_str = model_produced_args.get(f"q{i}")
+            if not q_str or not isinstance(q_str, str):
+                continue
+            parsed = _parse_legacy_question(q_str)
+            if not parsed:
+                return f"Error: q{i} invalid format"
+            raw.append(parsed)
 
-    if not validated:
-        return "Error: at least one valid question required"
+    validated, err = _validate_questions(raw)
+    if err:
+        return err
 
     summary = ", ".join(f"'{v['q'][:25]}' ({v['type']})" for v in validated)
     return f"⏸️WAIT_FOR_USER\nDisplaying {len(validated)} question(s): {summary}"


### PR DESCRIPTION
…bility

- Replace legacy q1-q6 string format with `questions` array of objects containing `text`, `type`, and optional `options`
- Add comprehensive validation for new format (length, required fields, etc.)
- Support legacy pipe-delimited format via `_parse_legacy_question`
- Update frontend ChatWindow to parse new structured format first
- Minor fix: prevent duplicate external auth connection in ChatWidgets