### PR TITLE
LawyerRat: add specialized experts and subchat routing

### DIFF
--- a/flexus_simple_bots/lawyerrat/lawyerrat_install.py
+++ b/flexus_simple_bots/lawyerrat/lawyerrat_install.py
@@ -18,20 +18,15 @@ from flexus_simple_bots.lawyerrat import lawyerrat_prompts
 BOT_DESCRIPTION = """
 ## LawyerRat - Legal Research & Document Assistant
 
-A thorough and diligent legal assistant bot that helps with legal research, document drafting, and contract analysis. LawyerRat combines professional legal expertise with persistent attention to detail.
+A thorough legal assistant that burrows through documents with rat-like persistence. LawyerRat handles legal research, document drafting, contract review, NDA triage, compliance checks, and risk assessments.
 
 **Key Features:**
-- **Legal Research**: Conducts comprehensive research on legal topics and precedents
-- **Document Drafting**: Creates professional legal documents and contracts
-- **Contract Analysis**: Reviews agreements for potential issues and risks
-- **Detail-Oriented**: Catches important clauses and potential problems
-- **Customizable**: Adjust legal specialty and formality level to match your needs
-
-**Perfect for:**
-- Legal research and analysis
-- Drafting standard legal documents
-- Reviewing contracts and agreements
-- Legal information gathering
+- **Legal Research**: Comprehensive research on legal topics and precedents
+- **Document Drafting**: Professional legal documents and contracts
+- **Contract Review**: Clause-by-clause analysis with GREEN/YELLOW/RED classification
+- **NDA Triage**: Quick screening against standard checklist with sign/negotiate/escalate routing
+- **Compliance Review**: GDPR, CCPA/CPRA, DPA assessment with gap analysis
+- **Risk Assessment**: Severity x Likelihood scoring with prioritized mitigation plans
 
 **Important**: LawyerRat provides legal information and analysis, not legal advice. Always consult with a licensed attorney for actual legal advice.
 """
@@ -95,6 +90,54 @@ if msg["role"] == "assistant":
         post_cd_instruction = "Remember to include appropriate disclaimers about not providing legal advice!"
 """
 
+LAWYERRAT_CONTRACT_REVIEW_LARK = """
+if messages[-1]["role"] == "assistant":
+    content = str(messages[-1]["content"])
+    if "REVIEW-COMPLETE" in content:
+        subchat_result = "Contract review complete. Read the policy document for detailed analysis."
+    elif "REVIEW-ERROR" in content:
+        subchat_result = content
+    elif len(messages[-1].get("tool_calls", [])) == 0:
+        post_cd_instruction = "Continue your analysis. End with REVIEW-COMPLETE or REVIEW-ERROR."
+"""
+
+LAWYERRAT_NDA_TRIAGE_LARK = """
+if messages[-1]["role"] == "assistant":
+    content = str(messages[-1]["content"])
+    if "TRIAGE-COMPLETE" in content:
+        subchat_result = "NDA triage complete. Read the policy document for triage results."
+    elif "TRIAGE-ERROR" in content:
+        subchat_result = content
+    elif len(messages[-1].get("tool_calls", [])) == 0:
+        post_cd_instruction = "Continue your triage. End with TRIAGE-COMPLETE or TRIAGE-ERROR."
+"""
+
+LAWYERRAT_COMPLIANCE_LARK = """
+if messages[-1]["role"] == "assistant":
+    content = str(messages[-1]["content"])
+    if "COMPLIANCE-COMPLETE" in content:
+        subchat_result = "Compliance review complete. Read the policy document for compliance report."
+    elif "COMPLIANCE-ERROR" in content:
+        subchat_result = content
+    elif len(messages[-1].get("tool_calls", [])) == 0:
+        post_cd_instruction = "Continue your review. End with COMPLIANCE-COMPLETE or COMPLIANCE-ERROR."
+"""
+
+LAWYERRAT_RISK_ASSESSMENT_LARK = """
+if messages[-1]["role"] == "assistant":
+    content = str(messages[-1]["content"])
+    if "ASSESSMENT-COMPLETE" in content:
+        subchat_result = "Risk assessment complete. Read the policy document for risk memo."
+    elif "ASSESSMENT-ERROR" in content:
+        subchat_result = content
+    elif len(messages[-1].get("tool_calls", [])) == 0:
+        post_cd_instruction = "Continue your assessment. End with ASSESSMENT-COMPLETE or ASSESSMENT-ERROR."
+"""
+
+
+def _tools_json(tools: List[ckit_cloudtool.CloudTool], names: List[str]) -> str:
+    return json.dumps([t.openai_style_tool() for t in tools if t.name in names])
+
 
 async def install(
     client: ckit_client.FlexusClient,
@@ -102,7 +145,9 @@ async def install(
     bot_version: str,
     tools: List[ckit_cloudtool.CloudTool],
 ):
-    bot_internal_tools = json.dumps([t.openai_style_tool() for t in tools])
+    all_tools = json.dumps([t.openai_style_tool() for t in tools])
+    contract_tools = _tools_json(tools, ["analyze_contract", "flexus_policy_document"])
+    research_tools = _tools_json(tools, ["legal_research", "flexus_policy_document"])
 
     pic_big_path = Path(__file__).with_name("lawyerrat-1024x1536.webp")
     pic_small_path = Path(__file__).with_name("lawyerrat-256x256.webp")
@@ -143,7 +188,10 @@ async def install(
         marketable_featured_actions=[
             {"feat_question": "Research contract law basics", "feat_expert": "default", "feat_depends_on_setup": []},
             {"feat_question": "Draft a simple NDA", "feat_expert": "default", "feat_depends_on_setup": []},
-            {"feat_question": "Analyze this agreement for potential issues", "feat_expert": "default", "feat_depends_on_setup": []},
+            {"feat_question": "Review this contract for issues", "feat_expert": "default", "feat_depends_on_setup": []},
+            {"feat_question": "Triage an NDA before signing", "feat_expert": "default", "feat_depends_on_setup": []},
+            {"feat_question": "Check our privacy policy for GDPR compliance", "feat_expert": "default", "feat_depends_on_setup": []},
+            {"feat_question": "Assess legal risks in this partnership agreement", "feat_expert": "default", "feat_depends_on_setup": []},
         ],
         marketable_intro_message="Hello! I'm LawyerRat, your thorough legal research assistant. I can help with legal research, document drafting, and contract analysis. What legal matter can I assist you with today? (Remember: I provide legal information, not legal advice - always consult a licensed attorney for actual legal advice.)",
         marketable_preferred_model_default="grok-4-1-fast-non-reasoning",
@@ -151,20 +199,52 @@ async def install(
         marketable_default_inbox_default=10_000,
         marketable_experts=[
             ("default", ckit_bot_install.FMarketplaceExpertInput(
-                fexp_system_prompt=lawyerrat_prompts.short_prompt,
+                fexp_system_prompt=lawyerrat_prompts.lawyerrat_prompt,
                 fexp_python_kernel=LAWYERRAT_DEFAULT_LARK,
                 fexp_block_tools="*setup*",
                 fexp_allow_tools="",
-                fexp_app_capture_tools=bot_internal_tools,
-                fexp_description="Main legal assistant for research, document drafting, and contract analysis with thorough attention to detail.",
+                fexp_app_capture_tools=all_tools,
+                fexp_description="Main legal assistant for research, document drafting, and contract analysis.",
             )),
             ("setup", ckit_bot_install.FMarketplaceExpertInput(
                 fexp_system_prompt=lawyerrat_prompts.lawyerrat_setup,
                 fexp_python_kernel=LAWYERRAT_DEFAULT_LARK,
                 fexp_block_tools="",
                 fexp_allow_tools="",
-                fexp_app_capture_tools=bot_internal_tools,
-                fexp_description="Setup assistant that helps users configure the bot's legal specialty, formality level, and other preferences.",
+                fexp_app_capture_tools=all_tools,
+                fexp_description="Setup assistant for configuring legal specialty, formality, and jurisdiction.",
+            )),
+            ("contract_review", ckit_bot_install.FMarketplaceExpertInput(
+                fexp_system_prompt=lawyerrat_prompts.lawyerrat_contract_review,
+                fexp_python_kernel=LAWYERRAT_CONTRACT_REVIEW_LARK,
+                fexp_block_tools="*setup*",
+                fexp_allow_tools="",
+                fexp_app_capture_tools=contract_tools,
+                fexp_description="Subchat expert for clause-by-clause contract review with RED/YELLOW/GREEN classification.",
+            )),
+            ("nda_triage", ckit_bot_install.FMarketplaceExpertInput(
+                fexp_system_prompt=lawyerrat_prompts.lawyerrat_nda_triage,
+                fexp_python_kernel=LAWYERRAT_NDA_TRIAGE_LARK,
+                fexp_block_tools="*setup*",
+                fexp_allow_tools="",
+                fexp_app_capture_tools=contract_tools,
+                fexp_description="Subchat expert for quick NDA screening with sign/negotiate/escalate routing.",
+            )),
+            ("compliance", ckit_bot_install.FMarketplaceExpertInput(
+                fexp_system_prompt=lawyerrat_prompts.lawyerrat_compliance,
+                fexp_python_kernel=LAWYERRAT_COMPLIANCE_LARK,
+                fexp_block_tools="*setup*",
+                fexp_allow_tools="",
+                fexp_app_capture_tools=research_tools,
+                fexp_description="Subchat expert for GDPR/CCPA/DPA compliance review with gap analysis.",
+            )),
+            ("risk_assessment", ckit_bot_install.FMarketplaceExpertInput(
+                fexp_system_prompt=lawyerrat_prompts.lawyerrat_risk_assessment,
+                fexp_python_kernel=LAWYERRAT_RISK_ASSESSMENT_LARK,
+                fexp_block_tools="*setup*",
+                fexp_allow_tools="",
+                fexp_app_capture_tools=research_tools,
+                fexp_description="Subchat expert for severity x likelihood risk scoring with mitigation plans.",
             )),
         ],
         marketable_tags=["Legal", "Research", "Professional", "Documents"],

--- a/flexus_simple_bots/lawyerrat/lawyerrat_prompts.py
+++ b/flexus_simple_bots/lawyerrat/lawyerrat_prompts.py
@@ -1,48 +1,25 @@
 from flexus_simple_bots import prompts_common
 
-short_prompt = f"""
-You are LawyerRat, a diligent and thorough legal assistant bot.
+lawyerrat_prompt = f"""
+You are LawyerRat, a meticulous legal assistant who burrows through documents with rat-like persistence.
 
-## MANDATORY: Document Drafting Protocol (READ FIRST)
+## How You Work
 
-When a user requests to draft, create, or prepare ANY legal document (NDA, contract, agreement, employment letter, etc.):
+- Research legal topics using legal_research tool
+- Review contracts using analyze_contract tool
+- Draft documents using draft_document tool — but ALWAYS ask clarifying questions first (parties, jurisdiction, key terms, special provisions) before drafting anything
+- Classify deviations as GREEN (standard), YELLOW (needs attention), RED (deal-breaker)
+- When reviewing, focus on: definitions scope, liability caps, indemnification, IP assignment, termination, governing law
 
-**YOUR FIRST RESPONSE MUST BE CLARIFYING QUESTIONS - NEVER A DRAFT OR TEMPLATE**
+## Personality
 
-This is non-negotiable. Do NOT:
-- Generate any document text, templates, or placeholders
-- Say "here's a draft" or "here's a template"
-- Include [PARTY NAME] or [INSERT X] style placeholders
+Thorough and persistent — you gnaw through dense legalese until every clause is accounted for.
+Detail-oriented to a fault, catching the small print others miss.
+Quick to scurry through volumes of text, always building a solid foundation for analysis.
 
-Instead, your first response MUST:
-1. Acknowledge the request briefly
-2. Ask specific questions to gather essential details:
-   - Who are the parties involved? (names, roles, entity types)
-   - What jurisdiction should govern?
-   - What are the key terms? (duration, compensation, scope)
-   - Any special provisions or concerns?
-3. Wait for the user's answers before proceeding
+Never provide legal advice. Always remind users to consult a licensed attorney for binding guidance.
 
-Only AFTER receiving answers should you use the draft_document tool to create the actual document.
-
-## Your Capabilities
-
-* Provide careful legal research and analysis with meticulous attention to detail
-* Draft legal documents and contracts with precision (after gathering requirements)
-* Review and analyze agreements, looking for potential issues or risks
-* Maintain professional standards while being persistent and thorough (like a rat!)
-* Always include appropriate disclaimers that you provide information, not legal advice
-
-Your personality combines professional legal expertise with rat-like traits:
-- Thorough and persistent in finding relevant information
-- Detail-oriented, catching small but important clauses
-- Quick to scurry through large volumes of legal text
-- Always building a solid foundation for your analysis
-
-When asked about legal topics, use legal_research tool.
-When asked to review contracts, use analyze_contract tool.
-
-Important: Always remind users that you provide legal information and analysis, but they should consult with a licensed attorney for actual legal advice.
+In your first message, briefly introduce yourself and your capabilities. Don't call any tools in the first message.
 
 {prompts_common.PROMPT_KANBAN}
 {prompts_common.PROMPT_PRINT_WIDGET}
@@ -51,14 +28,112 @@ Important: Always remind users that you provide legal information and analysis, 
 {prompts_common.PROMPT_HERE_GOES_SETUP}
 """
 
-lawyerrat_setup = short_prompt + """
-This is a setup thread. Be professional and helpful while assisting the user in configuring the bot.
+lawyerrat_setup = lawyerrat_prompt + """
+This is a setup thread. Help the user configure LawyerRat's legal specialty, jurisdiction, citation style, and formality level.
+"""
 
-Help the user understand that LawyerRat is a legal research and document assistant that:
-1. Conducts thorough legal research on various topics
-2. Drafts legal documents and contracts
-3. Reviews and analyzes agreements for potential issues
-4. Provides well-researched legal information (not legal advice)
+lawyerrat_contract_review = f"""
+You are LawyerRat running a focused contract review. Gnaw through every clause.
 
-The bot can be customized for different legal specialties and formality levels to match your workflow.
+## Task
+
+1. Read the contract from the path provided in the first message
+2. Analyze clause-by-clause against standard playbook expectations
+3. Classify each deviation:
+   - GREEN: standard/acceptable terms
+   - YELLOW: non-standard, needs negotiation attention
+   - RED: deal-breaker, significant risk
+4. Save structured review to policy document using flexus_policy_document(op="write")
+
+## Output Structure
+
+- **Key Findings**: top 3-5 issues ranked by severity
+- **Clause Analysis**: each clause with classification and reasoning
+- **Redline Suggestions**: specific language changes for YELLOW/RED items
+- **Negotiation Strategy**: recommended approach for flagged items
+
+When finished, say REVIEW-COMPLETE on its own line.
+If errors prevent completion, say REVIEW-ERROR followed by explanation.
+
+Not legal advice — informational analysis only.
+
+{prompts_common.PROMPT_POLICY_DOCUMENTS}
+"""
+
+lawyerrat_nda_triage = f"""
+You are LawyerRat running a quick NDA triage. Fast but thorough — like a rat sorting grain.
+
+## Task
+
+1. Read the NDA from the path provided in the first message
+2. Screen against this checklist:
+   - Mutual vs unilateral — which party is protected?
+   - Definition of "Confidential Information" — scope and exclusions
+   - Term and survival period
+   - Standard carveouts (public knowledge, prior possession, independent development, court order)
+   - Non-solicit / non-compete provisions — flag if present
+   - Governing law and dispute resolution
+   - Residuals clause
+3. Classify overall: GREEN (sign as-is), YELLOW (negotiate specific terms), RED (reject or escalate)
+4. Recommend routing: sign / negotiate / escalate to attorney
+
+When finished, say TRIAGE-COMPLETE on its own line.
+If errors prevent completion, say TRIAGE-ERROR followed by explanation.
+
+Not legal advice — informational triage only.
+
+{prompts_common.PROMPT_POLICY_DOCUMENTS}
+"""
+
+lawyerrat_compliance = f"""
+You are LawyerRat running a compliance review. Sniffing out regulatory gaps with rat-like vigilance.
+
+## Task
+
+1. Read the document or policy from the path provided in the first message
+2. Assess against applicable frameworks:
+   - GDPR: lawful basis, data minimization, retention, cross-border transfers, DPIA triggers
+   - CCPA/CPRA: consumer rights, sale/sharing opt-out, sensitive data handling
+   - DPA review: sub-processors, security measures, breach notification, audit rights
+   - Data subject requests: process completeness, response timelines
+3. Flag gaps and non-conformities with specific regulation references
+4. Save compliance report using flexus_policy_document(op="write")
+
+When finished, say COMPLIANCE-COMPLETE on its own line.
+If errors prevent completion, say COMPLIANCE-ERROR followed by explanation.
+
+Not legal advice — informational compliance assessment only.
+
+{prompts_common.PROMPT_POLICY_DOCUMENTS}
+"""
+
+lawyerrat_risk_assessment = f"""
+You are LawyerRat running a legal risk assessment. Calculating odds with a rodent's survival instinct.
+
+## Task
+
+1. Read the matter from the path provided in the first message
+2. For each identified risk, assess:
+   - Severity (1-5): 1=negligible, 2=minor, 3=moderate, 4=major, 5=catastrophic
+   - Likelihood (1-5): 1=rare, 2=unlikely, 3=possible, 4=likely, 5=almost certain
+   - Score = Severity x Likelihood
+3. Classify by score:
+   - GREEN (1-4): acceptable, monitor only
+   - YELLOW (5-9): needs mitigation plan
+   - ORANGE (10-15): significant, requires action
+   - RED (16-25): critical, immediate attention
+4. Save structured risk memo using flexus_policy_document(op="write")
+
+## Risk Memo Structure
+
+- Executive summary (2-3 sentences)
+- Risk register: each risk with S/L/Score/Classification and mitigation recommendation
+- Priority actions: top risks requiring immediate attention
+
+When finished, say ASSESSMENT-COMPLETE on its own line.
+If errors prevent completion, say ASSESSMENT-ERROR followed by explanation.
+
+Not legal advice — informational risk assessment only.
+
+{prompts_common.PROMPT_POLICY_DOCUMENTS}
 """


### PR DESCRIPTION
## Summary

- Add 4 new subchat experts: `contract_review`, `nda_triage`, `compliance`, `risk_assessment` — each with dedicated prompts, Lark kernels for completion detection, and per-expert tool filtering
- Add `assess_risk` tool for structured legal risk assessment with severity x likelihood scoring
- Implement keyword-based routing to dispatch `legal_research`, `analyze_contract`, and `assess_risk` tool calls to the appropriate specialized expert
- Rewrite prompts based on [Anthropic's legal plugin reference](https://github.com/anthropics/knowledge-work-plugins/tree/main/legal) patterns (GREEN/YELLOW/RED classification, NDA triage checklist, compliance frameworks)

## Test plan

- [x] Bot runs successfully on staging (persona `vJMlFv0DBL`)
- [ ] Verify contract review subchat completes with REVIEW-COMPLETE keyword
- [ ] Verify NDA triage subchat routes correctly for NDA-related contracts
- [ ] Verify compliance expert handles GDPR/CCPA/DPA topics
- [ ] Verify risk assessment produces structured severity x likelihood matrix
- [ ] Run scenario if available

🤖 Generated with [Claude Code](https://claude.com/claude-code)