### PR TITLE
Document fexp_app_capture_tools + flexus_fetch_skill requirement

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -310,6 +310,37 @@ Tradeoff: more source code we need to maintain vs accuracy on complex tasks.
 Implemented as tool that returns instructions as text.
 Examples: idea rating rules, ad platform specifics.
 
+Skills live in `skills/<skill-name>/SKILL.md` inside the bot directory (or `shared_skills/` at
+the repo root for cross-bot skills). Each SKILL.md has YAML frontmatter with `name` and `description`.
+
+**Important**: when an expert has skills (`fexp_builtin_skills` is non-empty), the backend requires
+`flexus_fetch_skill` tool in `fexp_app_capture_tools`. The `filter_tools()` method on
+`FMarketplaceExpertInput` handles this automatically — it appends the tool if skills are present.
+If you build a custom installer that bypasses `filter_tools()`, you must include it yourself or you'll
+get `400: fexp_builtin_skills requires flexus_fetch_skill in fexp_app_capture_tools`.
+
+The tool format used by `openai_style_tool()` places `strict` at the **top level** alongside `type`,
+not inside `function`:
+
+```
+{
+    "type": "function",
+    "function": {
+        "name": "flexus_fetch_skill",
+        "description": "Load a skill by name, returns the skill instructions.",
+        "parameters": {
+            "type": "object",
+            "properties": {"name": {"type": "string"}},
+            "required": ["name"],
+            "additionalProperties": false,
+        },
+    },
+    "strict": true,
+}
+```
+
+The backend rejects `strict` inside `function` with `bad keys: {'strict'}`.
+
 ### Subchat
 
 A separate thread with isolated context.


### PR DESCRIPTION
## Summary
- Documents that `fexp_app_capture_tools` must include `flexus_fetch_skill` when `fexp_builtin_skills` is non-empty
- Documents the OpenAI-style tool format with `strict` at top level (not inside `function`)
- Explains that `filter_tools()` handles this automatically, but custom installers need to include the tool manually

## Context
Discovered during RFP Quoter bot testing on staging. Building a custom installer (TypeScript) that bypasses `filter_tools()` results in:
```
400: fexp_builtin_skills requires flexus_fetch_skill in fexp_app_capture_tools
```
The requirement is enforced server-side but was undocumented. Additionally, placing `strict` inside `function` (following OpenAI's published format) produces `bad keys: {'strict'}`.

## Test plan
- [ ] Verify AGENTS.md renders correctly on GitHub
- [ ] Confirm the documented tool format matches `ckit_cloudtool.py:openai_style_tool()` output

🤖 Generated with [Claude Code](https://claude.com/claude-code)