### PR TITLE
fix: WebsocketsTransport max_size crashes pod-operator

### DIFF
--- a/flexus_client_kit/ckit_client.py
+++ b/flexus_client_kit/ckit_client.py
@@ -106,7 +106,7 @@ class FlexusClient:
                 "x-flexus-superuser": superpassword_curr,
                 "x-flexus-service-name": self.service_name,
             }
-        transport = WebsocketsTransport(url=self.websocket_url, init_payload=payload, keep_alive_timeout=120, ping_interval=30, pong_timeout=10, max_size=10_485_760)
+        transport = WebsocketsTransport(url=self.websocket_url, init_payload=payload, keep_alive_timeout=120, ping_interval=30, pong_timeout=10, connect_args={"max_size": 10_485_760})
         return gql.Client(transport=transport, fetch_schema_from_transport=False)
 
 


### PR DESCRIPTION
## Summary

- `gql 4.0.0` `WebsocketsTransport` does not accept `max_size` as a direct constructor parameter
- Pass it via `connect_args={"max_size": 10_485_760}` instead
- Fixes pod-operator CrashLoopBackOff on staging (introduced in commit 6586994)

## Root cause

Commit `6586994` added `max_size=10_485_760` directly to `WebsocketsTransport()`, but `gql 4.0.0` (installed on staging) doesn't support this parameter. The correct way is `connect_args={"max_size": ...}`.

## Impact

- **pod-operator** in CrashLoopBackOff — no bots can be started/managed
- Cascading DB connection pool exhaustion (P2028 transaction timeouts)
- All bot-related API calls returning intermittent 503

## Test plan

- [x] Verified `connect_args` works with `gql 4.0.0` locally
- [ ] Merge, rebuild staging image, verify pod-operator starts cleanly
- [ ] Verify bot lifecycle operations work (start/stop/scale)

🤖 Generated with [Claude Code](https://claude.com/claude-code)