### PR TITLE
Adopt FROG_INTEGRATIONS pattern in Vix bot

### DIFF
--- a/flexus_simple_bots/vix/vix_bot.py
+++ b/flexus_simple_bots/vix/vix_bot.py
@@ -17,15 +17,14 @@ from flexus_client_kit import ckit_mongo
 from flexus_client_kit import ckit_erp
 from flexus_client_kit import ckit_kanban
 from flexus_client_kit import erp_schema
+from flexus_client_kit import ckit_integrations_db
 from flexus_client_kit.integrations import fi_mongo_store
-from flexus_client_kit.integrations import fi_pdoc
 from flexus_client_kit.integrations import fi_erp
 from flexus_client_kit.integrations import fi_crm_automations
 from flexus_client_kit.integrations import fi_resend
 from flexus_client_kit.integrations import fi_shopify
 from flexus_client_kit.integrations import fi_telegram
 from flexus_client_kit.integrations import fi_crm
-from flexus_client_kit.integrations import fi_widget
 from flexus_simple_bots.vix import vix_install
 from flexus_simple_bots.version_common import SIMPLE_BOTS_COMMON_VERSION
 
@@ -36,9 +35,17 @@ BOT_VERSION = SIMPLE_BOTS_COMMON_VERSION
 
 ERP_TABLES = ["crm_contact", "crm_activity", "crm_deal", "com_shop", "com_product", "com_product_variant", "com_order", "com_order_item", "com_refund"]
 
+VIX_INTEGRATIONS: list[ckit_integrations_db.IntegrationRecord] = ckit_integrations_db.static_integrations_load(
+    vix_install.VIX_ROOTDIR,
+    allowlist=[
+        "flexus_policy_document",
+        "print_widget",
+    ],
+    builtin_skills=[],
+)
+
 TOOLS = [
     fi_mongo_store.MONGO_STORE_TOOL,
-    fi_pdoc.POLICY_DOCUMENT_TOOL,
     fi_erp.ERP_TABLE_META_TOOL,
     fi_erp.ERP_TABLE_DATA_TOOL,
     fi_erp.ERP_TABLE_CRUD_TOOL,
@@ -50,7 +57,7 @@ TOOLS = [
     fi_shopify.SHOPIFY_TOOL,
     fi_shopify.SHOPIFY_CART_TOOL,
     fi_telegram.TELEGRAM_TOOL,
-    fi_widget.PRINT_WIDGET_TOOL,
+    *[t for rec in VIX_INTEGRATIONS for t in rec.integr_tools],
 ]
 
 
@@ -64,7 +71,8 @@ async def vix_main_loop(fclient: ckit_client.FlexusClient, rcx: ckit_bot_exec.Ro
     mydb = mongo[dbname]
     personal_mongo = mydb["personal_mongo"]
 
-    pdoc_integration = fi_pdoc.IntegrationPdoc(rcx, rcx.persona.ws_root_group_id)
+    integr_objects = await ckit_integrations_db.main_loop_integrations_init(VIX_INTEGRATIONS, rcx)
+
     erp_integration = fi_erp.IntegrationErp(fclient, rcx.persona.ws_id, personal_mongo)
     crm_integration = fi_crm.IntegrationCrm(fclient, rcx.persona.ws_id)
     automations_integration = fi_crm_automations.IntegrationCrmAutomations(
@@ -146,10 +154,6 @@ async def vix_main_loop(fclient: ckit_client.FlexusClient, rcx: ckit_bot_exec.Ro
             model_produced_args,
         )
 
-    @rcx.on_tool_call(fi_pdoc.POLICY_DOCUMENT_TOOL.name)
-    async def toolcall_pdoc(toolcall: ckit_cloudtool.FCloudtoolCall, model_produced_args: Dict[str, Any]) -> str:
-        return await pdoc_integration.called_by_model(toolcall, model_produced_args)
-
     @rcx.on_tool_call(fi_erp.ERP_TABLE_META_TOOL.name)
     async def toolcall_erp_meta(toolcall: ckit_cloudtool.FCloudtoolCall, model_produced_args: Dict[str, Any]) -> str:
         return await erp_integration.handle_erp_meta(toolcall, model_produced_args)
@@ -193,10 +197,6 @@ async def vix_main_loop(fclient: ckit_client.FlexusClient, rcx: ckit_bot_exec.Ro
     @rcx.on_tool_call(fi_telegram.TELEGRAM_TOOL.name)
     async def toolcall_telegram(toolcall: ckit_cloudtool.FCloudtoolCall, model_produced_args: Dict[str, Any]) -> str:
         return await telegram.called_by_model(toolcall, model_produced_args)
-
-    @rcx.on_tool_call(fi_widget.PRINT_WIDGET_TOOL.name)
-    async def toolcall_print_widget(toolcall: ckit_cloudtool.FCloudtoolCall, model_produced_args: Dict[str, Any]) -> str:
-        return await fi_widget.handle_print_widget(toolcall, model_produced_args)
 
     @telegram.on_incoming_activity
     async def telegram_activity_callback(a: fi_telegram.ActivityTelegram, already_posted: bool):


### PR DESCRIPTION
## Summary
- Move `flexus_policy_document` and `print_widget` integrations from hard-wired imports to the `ckit_integrations_db` registry pattern, matching how LawyerRat and Frog bots handle integrations
- Replaces direct `fi_pdoc` / `fi_widget` imports, manual tool list entries, and manual `@rcx.on_tool_call` handler registrations with `VIX_INTEGRATIONS` + `main_loop_integrations_init()`
- Complex multi-tool integrations (ERP, CRM automations, resend, shopify, telegram) remain hard-wired as they require custom initialization signatures

## Test plan
- [ ] Verify Vix bot starts successfully on staging
- [ ] Verify `flexus_policy_document` tool still works (create/read policy docs)
- [ ] Verify `print_widget` tool still works
- [ ] Verify all other tools (ERP, email, shopify, telegram) are unaffected

Generated with [Claude Code](https://claude.com/claude-code)