### PR TITLE
feat(integrations): LinkedIn + LinkedIn B2B + generic handler

### DIFF
--- a/flexus_client_kit/ckit_integrations_db.py
+++ b/flexus_client_kit/ckit_integrations_db.py
@@ -1,3 +1,5 @@
+import importlib
+import inspect
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Awaitable, Callable
@@ -124,10 +126,7 @@ def static_integrations_load(bot_dir: Path, allowlist: list[str], builtin_skills
         elif name == "linkedin":
             from flexus_client_kit.integrations import fi_linkedin
             async def _init_linkedin(rcx, setup):
-                ad_account_id = (setup or {}).get("ad_account_id", "")
-                return fi_linkedin.IntegrationLinkedIn(
-                    rcx.fclient, rcx, ad_account_id=ad_account_id
-                )
+                return fi_linkedin.IntegrationLinkedIn(rcx)
             result.append(IntegrationRecord(
                 integr_name=name,
                 integr_tools=[fi_linkedin.LINKEDIN_TOOL],
@@ -135,11 +134,48 @@ def static_integrations_load(bot_dir: Path, allowlist: list[str], builtin_skills
                 integr_setup_handlers=lambda obj, rcx: [rcx.on_tool_call("linkedin")(obj.called_by_model)],
                 integr_provider="linkedin",
                 integr_scopes=[
-                    "r_profile_basicinfo",
+                    "openid",
+                    "profile",
                     "email",
                     "w_member_social",
                 ],
                 integr_prompt="",
+            ))
+
+        elif name == "linkedin_b2b":
+            from flexus_client_kit.integrations import fi_linkedin_b2b
+            async def _init_linkedin_b2b(rcx, setup):
+                return fi_linkedin_b2b.IntegrationLinkedinB2B(
+                    rcx,
+                    ad_account_id=(setup or {}).get("ad_account_id", ""),
+                    organization_id=(setup or {}).get("organization_id", ""),
+                    linkedin_api_version=(setup or {}).get("linkedin_api_version", "202509"),
+                )
+            result.append(IntegrationRecord(
+                integr_name=name,
+                integr_tools=[fi_linkedin_b2b.LINKEDIN_B2B_TOOL],
+                integr_init=_init_linkedin_b2b,
+                integr_setup_handlers=lambda obj, rcx: [rcx.on_tool_call("linkedin_b2b")(obj.called_by_model)],
+                integr_provider="linkedin",
+                integr_scopes=[
+                    "r_ads",
+                    "rw_ads",
+                    "r_ads_reporting",
+                    "r_organization_admin",
+                    "rw_organization_admin",
+                    "r_organization_social",
+                    "w_organization_social",
+                    "r_organization_social_feed",
+                    "w_organization_social_feed",
+                    "r_organization_followers",
+                    "r_events",
+                    "rw_events",
+                    "r_marketing_leadgen_automation",
+                    "rw_conversions",
+                    "r_member_profileAnalytics",
+                    "r_member_postAnalytics",
+                    "rw_dmp_segments",
+                ],
             ))
 
         elif name == "github":
@@ -247,7 +283,68 @@ def static_integrations_load(bot_dir: Path, allowlist: list[str], builtin_skills
             ))
 
         else:
-            raise ValueError(f"Unknown integration {name!r}")
+            # Generic handler for any fi_{name}.py integration that follows the standard pattern.
+            # Avoids writing an explicit elif branch for every one of the 70+ API providers.
+
+            # Import fi_{name}.py at runtime by name (e.g. "reddit" -> fi_reddit.py).
+            # We can't do this at the top of the file because the name is only known at call time.
+            mod = importlib.import_module(f"flexus_client_kit.integrations.fi_{name}")
+
+            # Each fi_*.py defines exactly one class named Integration* (e.g. IntegrationReddit).
+            # inspect.getmembers lists all class objects in the module.
+            # The c.__module__ == mod.__name__ guard skips classes that were *imported into* the
+            # module from elsewhere (e.g. base classes), keeping only the one defined there.
+            integration_class = next(
+                (c for _, c in inspect.getmembers(mod, inspect.isclass)
+                 if c.__name__.startswith("Integration") and c.__module__ == mod.__name__),
+                None,
+            )
+            if integration_class is None:
+                raise ValueError(f"No Integration* class found in fi_{name}.py")
+
+            # fi_*.py defines PROVIDER_NAME = "reddit" (may differ from the file name fi_x.py -> "x").
+            provider_name = getattr(mod, "PROVIDER_NAME", name)
+
+            # All fi_*.py integrations speak the same op=help|status|list_methods|call protocol,
+            # so one tool schema covers all of them.
+            generic_tool = ckit_cloudtool.CloudTool(
+                strict=True,
+                name=provider_name,
+                description=f"{provider_name}: data provider. op=help|status|list_methods|call",
+                parameters={
+                    "type": "object",
+                    "properties": {
+                        "op": {"type": "string", "enum": ["help", "status", "list_methods", "call"]},
+                        "args": {"type": ["object", "null"]},
+                    },
+                    "required": ["op", "args"],
+                    "additionalProperties": False,
+                },
+            )
+
+            # XXX: _make_generic_init is a factory function, not a plain closure, to avoid a
+            # classic Python loop-capture bug: without it, every closure would share the last
+            # iteration's integration_class after the loop completes.
+            def _make_generic_init(klass):
+                async def _init(rcx, setup, _cls=klass):
+                    # XXX: fi_*.py constructors are inconsistent: some accept (rcx), some accept
+                    # nothing. Try the more common (rcx) first; fall back to () on TypeError.
+                    try:
+                        return _cls(rcx)
+                    except TypeError:
+                        return _cls()
+                return _init
+
+            result.append(IntegrationRecord(
+                integr_name=provider_name,
+                integr_tools=[generic_tool],
+                integr_init=_make_generic_init(integration_class),
+                # _t=generic_tool captures the current tool into the lambda for the same reason
+                # as _make_generic_init above: without it all lambdas would share the last tool.
+                integr_setup_handlers=lambda obj, rcx, _t=generic_tool: [
+                    rcx.on_tool_call(_t.name)(obj.called_by_model)
+                ],
+            ))
     return result
 
 
@@ -257,7 +354,7 @@ def _parse_bracket_list(name: str) -> list[str] | None:
     return [g.strip() for g in name.split("[", 1)[1].rstrip("]").split(",")]
 
 
-async def main_loop_integrations_init(records: list[IntegrationRecord], rcx: ckit_bot_exec.RobotContext, setup: dict) -> dict[str, Any]:
+async def main_loop_integrations_init(records: list[IntegrationRecord], rcx, setup: dict | None = None) -> dict[str, Any]:
     from flexus_client_kit.integrations import fi_messenger
     if any(rec.integr_need_mongo for rec in records) and rcx.personal_mongo is None:
         from pymongo import AsyncMongoClient

--- a/flexus_client_kit/integrations/fi_linkedin.py
+++ b/flexus_client_kit/integrations/fi_linkedin.py
@@ -1,583 +1,332 @@
-import asyncio
+import json
 import logging
-import time
-from dataclasses import dataclass
-from typing import Dict, Any, Optional, List
+from typing import Any, Dict, Optional
 
 import httpx
 
-from flexus_client_kit import ckit_client
 from flexus_client_kit import ckit_cloudtool
-from flexus_client_kit import ckit_bot_exec
 
 
 logger = logging.getLogger("linkedin")
 
+PROVIDER_NAME = "linkedin"
+METHOD_IDS = [
+    "linkedin.auth.userinfo.get.v1",
+    "linkedin.posts.create_text.v1",
+    "linkedin.posts.create_article.v1",
+    "linkedin.assets.register_image_upload.v1",
+    "linkedin.assets.register_video_upload.v1",
+    "linkedin.posts.create_image.v1",
+    "linkedin.posts.create_video.v1",
+]
 
-AD_ACCOUNT_ID = "513489554"
-
-API_BASE = "https://api.linkedin.com"
-API_VERSION = "202509"
-
+_BASE_URL = "https://api.linkedin.com"
+_TIMEOUT = 30.0
 
 LINKEDIN_TOOL = ckit_cloudtool.CloudTool(
     strict=False,
     name="linkedin",
-    description="Interact with LinkedIn Ads API, call with op=\"help\" to print usage, call with op=\"status+help\" to see both status and help in one call",
+    description="LinkedIn open permissions: OIDC userinfo and member posting.",
     parameters={
         "type": "object",
         "properties": {
-            "op": {"type": "string", "description": "Start with 'help' for usage"},
+            "op": {"type": "string", "description": "Use help, status, list_methods, or call."},
             "args": {"type": "object"},
         },
-        "required": []
+        "required": [],
     },
 )
 
-
-HELP = """
-Help:
-
-linkedin(op="status")
-    Shows current LinkedIn Ads account status, lists all campaign groups with their campaigns.
-
-linkedin(op="list_campaign_groups")
-    Lists all campaign groups for ad account.
-
-linkedin(op="list_campaigns", args={"campaign_group_id": "123456", "status": "ACTIVE"})
-    Lists campaigns. Optional filters: campaign_group_id, status (ACTIVE, PAUSED, ARCHIVED, etc).
-
-linkedin(op="create_campaign_group", args={
-    "name": "Q1 2024 Campaigns",
-    "total_budget": 1000.0,
-    "currency": "USD",
-    "status": "ACTIVE"
-})
-    Creates a new campaign group with specified budget.
-
-linkedin(op="create_campaign", args={
-    "campaign_group_id": "123456",
-    "name": "Brand Awareness Campaign",
-    "objective": "BRAND_AWARENESS",
-    "daily_budget": 50.0,
-    "currency": "USD",
-    "status": "PAUSED"
-})
-    Creates a campaign in a campaign group.
-    Valid objectives: BRAND_AWARENESS, WEBSITE_VISITS, ENGAGEMENT, VIDEO_VIEWS, LEAD_GENERATION, WEBSITE_CONVERSIONS, JOB_APPLICANTS
-
-linkedin(op="get_campaign", args={"campaign_id": "123456"})
-    Gets details for a specific campaign.
-
-linkedin(op="update_campaign", args={"campaign_id": "123456", "status": "ACTIVE", "daily_budget": 100.0})
-    Updates campaign settings. Optional: status, daily_budget, name.
-
-linkedin(op="get_analytics", args={"campaign_id": "123456", "days": 30})
-    Gets analytics for a campaign. Default: last 30 days.
-"""
-
-LINKEDIN_SETUP_SCHEMA = [
-    {
-        "bs_name": "ad_account_id",
-        "bs_type": "string_short",
-        "bs_default": "",
-        "bs_group": "LinkedIn",
-        "bs_importance": 1,
-        "bs_description": "LinkedIn Ads Account ID",
-    },
-]
-
-
-@dataclass
-class Budget:
-    amount: str
-    currency_code: str
-
-
-@dataclass
-class CampaignGroup:
-    id: str
-    name: str
-    status: str
-    total_budget: Optional[Budget] = None
-
-
-@dataclass
-class Campaign:
-    id: str
-    name: str
-    status: str
-    objective_type: str
-    daily_budget: Budget
-    campaign_group_id: Optional[str] = None
-
-
-@dataclass
-class Analytics:
-    impressions: int
-    clicks: int
-    cost: float
+# Open-permissions LinkedIn does not need per-bot setup fields.
+# Credentials are not pasted into this file or bot setup.
+# They must already exist in the platform auth provider named "linkedin".
+# Required provider-side values are:
+# - client_id: LinkedIn app Client ID from developer.linkedin.com
+# - client_secret: LinkedIn app Client Secret from developer.linkedin.com
+# - redirect_uri: the Flexus OAuth callback URL configured in the platform auth layer
+# - scopes: at minimum openid, profile, email, w_member_social
+# After user OAuth completes, Flexus must store the connected account under
+# rcx.external_auth["linkedin"], with token.access_token populated.
+# Optional refresh flow data, if available in the auth layer, also belongs there.
+LINKEDIN_SETUP_SCHEMA = []
 
 
 class IntegrationLinkedIn:
-    def __init__(
-        self,
-        fclient: ckit_client.FlexusClient,
-        rcx: ckit_bot_exec.RobotContext,
-        ad_account_id: str,
-    ):
-        self.fclient = fclient
+    def __init__(self, rcx=None):
         self.rcx = rcx
-        self.access_token = ""
-        self.ad_account_id = ad_account_id or AD_ACCOUNT_ID
-        self.problems = []
-        self._campaign_groups_cache = None
-        self._campaigns_cache = None
-        self._last_access_token = None
 
-    async def called_by_model(self, toolcall: ckit_cloudtool.FCloudtoolCall, model_produced_args: Optional[Dict[str, Any]]) -> str:
-        if not model_produced_args:
-            return HELP
+    def _auth(self) -> Dict[str, Any]:
+        # This integration only reads already-connected OAuth data.
+        # Where to paste values:
+        # - app-level keys such as client_id/client_secret belong in the platform auth provider "linkedin"
+        # - user-level access tokens belong in the connected external auth record for provider "linkedin"
+        # Expected token shape:
+        # {
+        #   "token": {
+        #     "access_token": "...",
+        #     "refresh_token": "...",   # optional, if your auth layer supports refresh
+        #   }
+        # }
+        # Legacy fallback oauth_token is still accepted to keep the read path simple.
+        return (self.rcx.external_auth.get("linkedin") or {}) if self.rcx else {}
 
-        linkedin_auth = self.rcx.external_auth.get("linkedin") or {}
-        token_obj = linkedin_auth.get("token") or {}
-        self.access_token = token_obj.get("access_token", "")
-        self._last_access_token = self.access_token
+    def _access_token(self) -> str:
+        auth = self._auth()
+        token_obj = auth.get("token") or {}
+        return str(token_obj.get("access_token", "") or auth.get("oauth_token", "")).strip()
 
-        if not self.access_token:
-            return "❌ LinkedIn not connected. Please connect LinkedIn in workspace settings.\n\nTry linkedin(op='help') for usage."
+    def _status(self) -> str:
+        access_token = self._access_token()
+        return json.dumps({
+            "ok": bool(access_token),
+            "provider": PROVIDER_NAME,
+            "status": "ready" if access_token else "missing_credentials",
+            "method_count": len(METHOD_IDS),
+            "auth_provider": "linkedin",
+            "products": [
+                "Sign in with LinkedIn using OpenID Connect",
+                "Share on LinkedIn",
+            ],
+            "scopes_expected": ["openid", "profile", "email", "w_member_social"],
+            "has_access_token": bool(access_token),
+        }, indent=2, ensure_ascii=False)
 
-        self.headers = {
-            "Authorization": f"Bearer {self.access_token}",
-            "Content-Type": "application/json",
+    def _help(self) -> str:
+        return (
+            f"provider={PROVIDER_NAME}\n"
+            "op=help | status | list_methods | call\n"
+            f"methods: {', '.join(METHOD_IDS)}\n"
+            "notes:\n"
+            "- auth.userinfo.get returns OIDC userinfo from /v2/userinfo\n"
+            "- register_*_upload returns uploadUrl + asset for a later binary upload step\n"
+            "- create_image/create_video require an already uploaded asset URN\n"
+        )
+
+    def _headers(self, *, has_body: bool) -> Dict[str, str]:
+        access_token = self._access_token()
+        headers = {
+            "Authorization": f"Bearer {access_token}",
             "X-Restli-Protocol-Version": "2.0.0",
-            "LinkedIn-Version": API_VERSION,
         }
+        if has_body:
+            headers["Content-Type"] = "application/json"
+        return headers
 
-        op = model_produced_args.get("op", "")
-        args, args_error = ckit_cloudtool.sanitize_args(model_produced_args)
-        if args_error:
-            return args_error
+    def _auth_missing(self, method_id: str) -> str:
+        return json.dumps({
+            "ok": False,
+            "provider": PROVIDER_NAME,
+            "method_id": method_id,
+            "error_code": "AUTH_MISSING",
+            "message": "Connect LinkedIn in workspace settings and ensure an access token is present.",
+        }, indent=2, ensure_ascii=False)
 
-        print_help = False
-        print_status = False
-        r = ""
+    def _invalid_args(self, method_id: str, message: str) -> str:
+        return json.dumps({
+            "ok": False,
+            "provider": PROVIDER_NAME,
+            "method_id": method_id,
+            "error_code": "INVALID_ARGS",
+            "message": message,
+        }, indent=2, ensure_ascii=False)
 
-        if not op or "help" in op:
-            print_help = True
-        if not op or "status" in op:
-            print_status = True
+    def _result(self, method_id: str, result: Any) -> str:
+        return json.dumps({
+            "ok": True,
+            "provider": PROVIDER_NAME,
+            "method_id": method_id,
+            "result": result,
+        }, indent=2, ensure_ascii=False)
 
-        if print_status:
-            r += f"LinkedIn Ads Account: {self.ad_account_id}\n"
-
-            await self._refresh_cache()
-            if self._campaign_groups_cache:
-                r += f"Campaign Groups ({len(self._campaign_groups_cache)}):\n"
-                for group in self._campaign_groups_cache:
-                    r += f"  📁 {group.name} (ID: {group.id}, Status: {group.status})"
-                    if group.total_budget:
-                        r += f" - Budget: {group.total_budget.amount} {group.total_budget.currency_code}"
-                    r += "\n"
-
-                    group_campaigns = [c for c in (self._campaigns_cache or []) if c.campaign_group_id == group.id]
-                    if group_campaigns:
-                        for campaign in group_campaigns:
-                            r += f"    📊 {campaign.name} (ID: {campaign.id})"
-                            r += f"       Objective: {campaign.objective_type}, Daily Budget: {campaign.daily_budget.amount} {campaign.daily_budget.currency_code}\n"
-                    else:
-                        r += f"    (no campaigns)\n"
-            else:
-                r += "No campaign groups found or failed to fetch.\n"
-
-            if self.problems:
-                r += "\nProblems:\n"
-                for problem in self.problems:
-                    r += f"  {problem}\n"
-            r += "\n"
-
-        if print_help:
-            r += HELP
-
-        elif print_status:
+    def _provider_error(self, method_id: str, status_code: int, body: str) -> str:
+        detail: Any = body[:500]
+        try:
+            detail = json.loads(body)
+        except json.JSONDecodeError:
             pass
+        logger.info("linkedin api error method=%s status=%s body=%s", method_id, status_code, body[:300])
+        return json.dumps({
+            "ok": False,
+            "provider": PROVIDER_NAME,
+            "method_id": method_id,
+            "error_code": "PROVIDER_ERROR",
+            "http_status": status_code,
+            "detail": detail,
+        }, indent=2, ensure_ascii=False)
 
-        elif op == "list_campaign_groups":
-            result = await self._list_campaign_groups()
-            if result:
-                r += f"Found {len(result)} campaign groups:\n"
-                for group in result:
-                    r += f"  {group.name} (ID: {group.id}, Status: {group.status})"
-                    if group.total_budget:
-                        r += f" - Budget: {group.total_budget.amount} {group.total_budget.currency_code}"
-            else:
-                r += "No campaign groups found.\n"
-
-        elif op == "list_campaigns":
-            campaign_group_id = ckit_cloudtool.try_best_to_find_argument(args, model_produced_args, "campaign_group_id", None)
-            status_filter = ckit_cloudtool.try_best_to_find_argument(args, model_produced_args, "status", None)
-            result = await self._list_campaigns(status_filter=status_filter)
-            if result:
-                campaigns = result
-                if campaign_group_id:
-                    campaigns = [c for c in campaigns if c.campaign_group_id == campaign_group_id]
-                r += f"Found {len(campaigns)} campaigns:\n"
-                for campaign in campaigns:
-                    r += f"  {campaign.name} (ID: {campaign.id})"
-                    r += f"    Status: {campaign.status}, Objective: {campaign.objective_type}"
-                    r += f"    Daily Budget: {campaign.daily_budget.amount} {campaign.daily_budget.currency_code}\n"
-            else:
-                r += "No campaigns found.\n"
-
-        elif op == "create_campaign_group":
-            name = ckit_cloudtool.try_best_to_find_argument(args, model_produced_args, "name", "")
-            total_budget = float(ckit_cloudtool.try_best_to_find_argument(args, model_produced_args, "total_budget", "1000.0"))
-            currency = ckit_cloudtool.try_best_to_find_argument(args, model_produced_args, "currency", "USD")
-            status = ckit_cloudtool.try_best_to_find_argument(args, model_produced_args, "status", "ACTIVE")
-
-            if not name:
-                return "ERROR: name parameter required for create_campaign_group\n"
-
-            result = await self._create_campaign_group(name, total_budget, currency, status)
-            if result:
-                self._campaign_groups_cache = None
-                r += f"✅ Campaign group created: {result.name} (ID: {result.id})\n"
-            else:
-                r += "❌ Failed to create campaign group. Check logs for details.\n"
-
-        elif op == "create_campaign":
-            campaign_group_id = ckit_cloudtool.try_best_to_find_argument(args, model_produced_args, "campaign_group_id", "")
-            name = ckit_cloudtool.try_best_to_find_argument(args, model_produced_args, "name", "")
-            objective = ckit_cloudtool.try_best_to_find_argument(args, model_produced_args, "objective", "BRAND_AWARENESS")
-            daily_budget = float(ckit_cloudtool.try_best_to_find_argument(args, model_produced_args, "daily_budget", "10.0"))
-            currency = ckit_cloudtool.try_best_to_find_argument(args, model_produced_args, "currency", "USD")
-            status = ckit_cloudtool.try_best_to_find_argument(args, model_produced_args, "status", "PAUSED")
-
-            if not campaign_group_id or not name:
-                return "ERROR: campaign_group_id and name parameters required for create_campaign\n"
-
-            result = await self._create_campaign(campaign_group_id, name, objective, daily_budget, currency, status)
-            if result:
-                self._campaigns_cache = None
-                r += f"✅ Campaign created: {result.name} (ID: {result.id})\n"
-                r += f"   Status: {result.status}, Objective: {result.objective_type}"
-                r += f"   Daily Budget: {result.daily_budget.amount} {result.daily_budget.currency_code}\n"
-            else:
-                r += "❌ Failed to create campaign. Check logs for details.\n"
-
-        elif op == "get_campaign":
-            campaign_id = ckit_cloudtool.try_best_to_find_argument(args, model_produced_args, "campaign_id", "")
-            if not campaign_id:
-                return "ERROR: campaign_id parameter required for get_campaign\n"
-
-            result = await self._get_campaign(campaign_id)
-            if result:
-                r += f"Campaign: {result.name} (ID: {result.id})\n"
-                r += f"  Status: {result.status}\n"
-                r += f"  Objective: {result.objective_type}\n"
-                r += f"  Daily Budget: {result.daily_budget.amount} {result.daily_budget.currency_code}\n"
-            else:
-                r += f"❌ Failed to get campaign {campaign_id}\n"
-
-        elif op == "get_analytics":
-            campaign_id = ckit_cloudtool.try_best_to_find_argument(args, model_produced_args, "campaign_id", "")
-            days = int(ckit_cloudtool.try_best_to_find_argument(args, model_produced_args, "days", "30"))
-
-            if not campaign_id:
-                return "ERROR: campaign_id parameter required for get_analytics\n"
-
-            result = await self._get_campaign_analytics(campaign_id, days)
-            if result:
-                r += f"Analytics for campaign {campaign_id} (last {days} days):\n"
-                r += f"  Impressions: {result.impressions:,}\n"
-                r += f"  Clicks: {result.clicks:,}\n"
-                r += f"  Cost: ${result.cost:.2f}\n"
-                if result.impressions > 0:
-                    ctr = (result.clicks / result.impressions) * 100
-                    r += f"  CTR: {ctr:.2f}%\n"
-                if result.clicks > 0:
-                    cpc = result.cost / result.clicks
-                    r += f"  CPC: ${cpc:.2f}\n"
-            else:
-                r += f"❌ Failed to get analytics for campaign {campaign_id}\n"
-
-        else:
-            r += f"Unknown operation {op!r}, try \"help\"\n\n"
-
-        return r
-
-    async def _refresh_cache(self):
-        """Refresh campaign groups and campaigns cache"""
-        self._campaign_groups_cache = await self._list_campaign_groups()
-        self._campaigns_cache = await self._list_campaigns()
-
-    async def _list_campaign_groups(self) -> Optional[List[CampaignGroup]]:
-        url = f"{API_BASE}/rest/adAccounts/{self.ad_account_id}/adCampaignGroups?q=search"
-        logger.info(f"Listing campaign groups for account: {self.ad_account_id}")
-        try:
-            async with httpx.AsyncClient() as client:
-                response = await client.get(url, headers=self.headers, timeout=30.0)
-                if response.status_code == 200:
-                    data = response.json()
-                    elements = data.get("elements", [])
-                    groups = []
-                    for elem in elements:
-                        budget_data = elem.get("totalBudget")
-                        groups.append(CampaignGroup(
-                            id=elem["id"],
-                            name=elem["name"],
-                            status=elem["status"],
-                            total_budget=Budget(
-                                amount=budget_data["amount"],
-                                currency_code=budget_data["currencyCode"],
-                            ) if budget_data else None,
-                        ))
-                    return groups
-                else:
-                    logger.error(f"Failed to list campaign groups: {response.status_code} - {response.text}")
-                    self.problems.append(f"Failed to list campaign groups: {response.status_code}")
-                    return None
-        except Exception as e:
-            logger.exception("Exception listing campaign groups")
-            self.problems.append(f"Exception listing campaign groups: {e}")
-            return None
-
-    async def _list_campaigns(self, status_filter: Optional[str] = None) -> Optional[List[Campaign]]:
-        params = {"q": "search"}
-        if status_filter:
-            params["search"] = f"(status:(values:List({status_filter})))"
-        url = f"{API_BASE}/rest/adAccounts/{self.ad_account_id}/adCampaigns"
-        logger.info(f"Listing campaigns for account: {self.ad_account_id}")
-        try:
-            async with httpx.AsyncClient() as client:
-                response = await client.get(url, params=params, headers=self.headers, timeout=30.0)
-                if response.status_code == 200:
-                    data = response.json()
-                    elements = data.get("elements", [])
-                    campaigns = []
-                    for elem in elements:
-                        budget_data = elem["dailyBudget"]
-                        campaign_group_urn = elem.get("campaignGroup", "")
-                        campaign_group_id = campaign_group_urn.split(":")[-1] if campaign_group_urn else None
-                        campaigns.append(Campaign(
-                            id=elem["id"],
-                            name=elem["name"],
-                            status=elem["status"],
-                            objective_type=elem["objectiveType"],
-                            daily_budget=Budget(
-                                amount=budget_data["amount"],
-                                currency_code=budget_data["currencyCode"],
-                            ),
-                            campaign_group_id=campaign_group_id,
-                        ))
-                    return campaigns
-                else:
-                    logger.error(f"Failed to list campaigns: {response.status_code} - {response.text}")
-                    self.problems.append(f"Failed to list campaigns: {response.status_code}")
-                    return None
-        except Exception as e:
-            logger.exception("Exception listing campaigns")
-            self.problems.append(f"Exception listing campaigns: {e}")
-            return None
-
-    async def _create_campaign_group(
+    async def called_by_model(
         self,
-        name: str,
-        total_budget_amount: float,
-        total_budget_currency: str,
-        status: str,
-    ) -> Optional[CampaignGroup]:
-        account_urn = f"urn:li:sponsoredAccount:{self.ad_account_id}"
-        start_time = int(time.time() * 1000)
-        end_time = start_time + (30 * 86400 * 1000)
-        payload = {
-            "account": account_urn,
-            "name": name,
-            "status": status,
-            "runSchedule": {
-                "start": start_time,
-                "end": end_time,
+        toolcall: ckit_cloudtool.FCloudtoolCall,
+        model_produced_args: Optional[Dict[str, Any]],
+    ) -> str:
+        args = model_produced_args or {}
+        op = str(args.get("op", "help")).strip()
+        if op == "help":
+            return self._help()
+        if op == "status":
+            return self._status()
+        if op == "list_methods":
+            return json.dumps({"ok": True, "provider": PROVIDER_NAME, "method_ids": METHOD_IDS}, indent=2, ensure_ascii=False)
+        if op != "call":
+            return "Error: unknown op. Use help/status/list_methods/call."
+
+        call_args = args.get("args") or {}
+        method_id = str(call_args.get("method_id", "")).strip()
+        if not method_id:
+            return "Error: args.method_id required for op=call."
+        if method_id not in METHOD_IDS:
+            return json.dumps({"ok": False, "error_code": "METHOD_UNKNOWN", "method_id": method_id}, indent=2, ensure_ascii=False)
+        if not self._access_token():
+            return self._auth_missing(method_id)
+        return await self._dispatch(method_id, call_args)
+
+    async def _request(
+        self,
+        method_id: str,
+        http_method: str,
+        path: str,
+        *,
+        body: Optional[Dict[str, Any]] = None,
+    ) -> str:
+        url = _BASE_URL + path
+        try:
+            async with httpx.AsyncClient(timeout=_TIMEOUT) as client:
+                if http_method == "GET":
+                    response = await client.get(url, headers=self._headers(has_body=False))
+                elif http_method == "POST":
+                    response = await client.post(url, headers=self._headers(has_body=True), json=body)
+                else:
+                    return json.dumps({"ok": False, "error_code": "UNSUPPORTED_HTTP_METHOD"}, indent=2, ensure_ascii=False)
+        except httpx.TimeoutException:
+            return json.dumps({"ok": False, "provider": PROVIDER_NAME, "method_id": method_id, "error_code": "TIMEOUT"}, indent=2, ensure_ascii=False)
+        except (httpx.HTTPError, ValueError) as e:
+            logger.error("linkedin request failed", exc_info=e)
+            return json.dumps({
+                "ok": False,
+                "provider": PROVIDER_NAME,
+                "method_id": method_id,
+                "error_code": "HTTP_ERROR",
+                "message": f"{type(e).__name__}: {e}",
+            }, indent=2, ensure_ascii=False)
+
+        if response.status_code >= 400:
+            return self._provider_error(method_id, response.status_code, response.text)
+
+        if not response.text.strip():
+            return self._result(method_id, {})
+        try:
+            return self._result(method_id, response.json())
+        except json.JSONDecodeError:
+            return self._result(method_id, response.text)
+
+    def _build_share_payload(self, args: Dict[str, Any], media_category: str) -> Dict[str, Any]:
+        author = str(args.get("author", "")).strip()
+        text = str(args.get("text", "") or args.get("commentary", "")).strip()
+        visibility = str(args.get("visibility", "PUBLIC")).strip().upper()
+        if not author:
+            raise ValueError("author is required and must be a Person URN such as urn:li:person:123.")
+        if not text:
+            raise ValueError("text is required.")
+
+        share_content: Dict[str, Any] = {
+            "shareCommentary": {"text": text},
+            "shareMediaCategory": media_category,
+        }
+        if media_category == "ARTICLE":
+            original_url = str(args.get("original_url", "") or args.get("url", "")).strip()
+            if not original_url:
+                raise ValueError("original_url is required for article posts.")
+            share_content["media"] = [{
+                "status": "READY",
+                "originalUrl": original_url,
+                **({"title": {"text": str(args.get("title", "")).strip()}} if str(args.get("title", "")).strip() else {}),
+                **({"description": {"text": str(args.get("description", "")).strip()}} if str(args.get("description", "")).strip() else {}),
+            }]
+        if media_category in {"IMAGE", "VIDEO"}:
+            asset = str(args.get("asset", "")).strip()
+            if not asset:
+                raise ValueError("asset is required for image/video posts. Register and upload media first.")
+            share_content["media"] = [{
+                "status": "READY",
+                "media": asset,
+                **({"title": {"text": str(args.get("title", "")).strip()}} if str(args.get("title", "")).strip() else {}),
+                **({"description": {"text": str(args.get("description", "")).strip()}} if str(args.get("description", "")).strip() else {}),
+            }]
+
+        return {
+            "author": author,
+            "lifecycleState": "PUBLISHED",
+            "specificContent": {
+                "com.linkedin.ugc.ShareContent": share_content,
             },
-            "totalBudget": {
-                "amount": str(total_budget_amount),
-                "currencyCode": total_budget_currency,
+            "visibility": {
+                "com.linkedin.ugc.MemberNetworkVisibility": visibility,
             },
         }
-        url = f"{API_BASE}/rest/adAccounts/{self.ad_account_id}/adCampaignGroups"
-        logger.info(f"Creating campaign group: {name}")
-        try:
-            async with httpx.AsyncClient() as client:
-                response = await client.post(url, json=payload, headers=self.headers, timeout=30.0)
-                if response.status_code == 201:
-                    campaign_group_id = response.headers["x-restli-id"]
-                    return CampaignGroup(
-                        id=campaign_group_id,
-                        name=name,
-                        status=status,
-                        total_budget=Budget(
-                            amount=str(total_budget_amount),
-                            currency_code=total_budget_currency,
-                        ),
-                    )
-                else:
-                    logger.error(f"Failed to create campaign group: {response.status_code} - {response.text}")
-                    self.problems.append(f"Failed to create campaign group: {response.status_code}")
-                    return None
-        except Exception as e:
-            logger.exception("Exception creating campaign group")
-            self.problems.append(f"Exception creating campaign group: {e}")
-            return None
 
-    async def _create_campaign(
-        self,
-        campaign_group_id: str,
-        name: str,
-        objective_type: str,
-        daily_budget_amount: float,
-        daily_budget_currency: str,
-        status: str,
-    ) -> Optional[Campaign]:
-        valid_objectives = ["BRAND_AWARENESS", "WEBSITE_VISITS", "ENGAGEMENT", "VIDEO_VIEWS", "LEAD_GENERATION", "WEBSITE_CONVERSIONS", "JOB_APPLICANTS"]
-        if objective_type not in valid_objectives:
-            logger.error(f"Invalid objective_type: {objective_type}")
-            self.problems.append(f"Invalid objective_type: {objective_type}. Valid: {', '.join(valid_objectives)}")
-            return None
-
-        account_urn = f"urn:li:sponsoredAccount:{self.ad_account_id}"
-        campaign_group_urn = f"urn:li:sponsoredCampaignGroup:{campaign_group_id}"
-        payload = {
-            "account": account_urn,
-            "campaignGroup": campaign_group_urn,
-            "name": name,
-            "type": "SPONSORED_UPDATES",
-            "objectiveType": objective_type,
-            "status": status,
-            "dailyBudget": {
-                "amount": str(daily_budget_amount),
-                "currencyCode": daily_budget_currency,
-            },
-            "unitCost": {
-                "amount": "10.0",
-                "currencyCode": daily_budget_currency,
-            },
-            "costType": "CPM",
-            "offsiteDeliveryEnabled": False,
-            "locale": {"country": "US", "language": "en"},
-            "runSchedule": {
-                "start": int(time.time() * 1000),
-            },
-            "politicalIntent": "NOT_POLITICAL",
+    def _build_register_upload_payload(self, args: Dict[str, Any], recipe_suffix: str) -> Dict[str, Any]:
+        owner = str(args.get("owner", "")).strip()
+        if not owner:
+            raise ValueError("owner is required and must be a Person URN such as urn:li:person:123.")
+        return {
+            "registerUploadRequest": {
+                "recipes": [f"urn:li:digitalmediaRecipe:feedshare-{recipe_suffix}"],
+                "owner": owner,
+                "serviceRelationships": [
+                    {
+                        "relationshipType": "OWNER",
+                        "identifier": "urn:li:userGeneratedContent",
+                    }
+                ],
+            }
         }
-        url = f"{API_BASE}/rest/adAccounts/{self.ad_account_id}/adCampaigns"
-        logger.info(f"Creating campaign: {name}")
+
+    async def _dispatch(self, method_id: str, args: Dict[str, Any]) -> str:
         try:
-            async with httpx.AsyncClient() as client:
-                response = await client.post(url, json=payload, headers=self.headers, timeout=30.0)
-                if response.status_code == 201:
-                    logger.info(f"Campaign created - headers: {dict(response.headers)}")
-                    campaign_id = response.headers["x-restli-id"]
-                    return Campaign(
-                        id=campaign_id,
-                        name=name,
-                        status=status,
-                        objective_type=objective_type,
-                        daily_budget=Budget(
-                            amount=str(daily_budget_amount),
-                            currency_code=daily_budget_currency,
-                        ),
-                        campaign_group_id=campaign_group_id,
-                    )
-                else:
-                    logger.error(f"Failed to create campaign: {response.status_code} - {response.text}")
-                    self.problems.append(f"Failed to create campaign: {response.status_code}")
-                    return None
-        except Exception as e:
-            logger.exception("Exception creating campaign")
-            self.problems.append(f"Exception creating campaign: {e}")
-            return None
-
-    async def _get_campaign(self, campaign_id: str) -> Optional[Campaign]:
-        url = f"{API_BASE}/rest/adAccounts/{self.ad_account_id}/adCampaigns/{campaign_id}"
-        logger.info(f"Fetching campaign: {campaign_id}")
-        try:
-            async with httpx.AsyncClient() as client:
-                response = await client.get(url, headers=self.headers, timeout=30.0)
-                if response.status_code == 200:
-                    data = response.json()
-                    budget_data = data["dailyBudget"]
-                    campaign_group_urn = data.get("campaignGroup", "")
-                    campaign_group_id = campaign_group_urn.split(":")[-1] if campaign_group_urn else None
-                    return Campaign(
-                        id=data["id"],
-                        name=data["name"],
-                        status=data["status"],
-                        objective_type=data["objectiveType"],
-                        daily_budget=Budget(
-                            amount=budget_data["amount"],
-                            currency_code=budget_data["currencyCode"],
-                        ),
-                        campaign_group_id=campaign_group_id,
-                    )
-                else:
-                    logger.error(f"Failed to get campaign: {response.status_code} - {response.text}")
-                    self.problems.append(f"Failed to get campaign: {response.status_code}")
-                    return None
-        except Exception as e:
-            logger.exception("Exception fetching campaign")
-            self.problems.append(f"Exception fetching campaign: {e}")
-            return None
-
-    async def _get_campaign_analytics(
-        self,
-        campaign_id: str,
-        days: int = 30,
-    ) -> Optional[Analytics]:
-        from datetime import datetime, timedelta
-
-        end_date = datetime.utcnow()
-        start_date = end_date - timedelta(days=days)
-        date_range = (
-            f"(start:(year:{start_date.year},month:{start_date.month},day:{start_date.day}),"
-            f"end:(year:{end_date.year},month:{end_date.month},day:{end_date.day}))"
-        )
-
-        campaign_urn = f"urn%3Ali%3AsponsoredCampaign%3A{campaign_id}"
-
-        url = (
-            f"{API_BASE}/rest/adAnalytics?"
-            f"q=analytics&"
-            f"pivot=CAMPAIGN&"
-            f"campaigns=List({campaign_urn})&"
-            f"timeGranularity=DAILY&"
-            f"dateRange={date_range}&"
-            f"fields=impressions,clicks,costInLocalCurrency"
-        )
-        logger.info(f"Fetching analytics for campaign: {campaign_id}")
-        try:
-            async with httpx.AsyncClient(timeout=30.0) as client:
-                headers = {k: v for k, v in self.headers.items() if k != "Content-Type"}
-                request = httpx.Request("GET", url, headers=headers)
-                response = await client.send(request)
-                if response.status_code == 200:
-                    data = response.json()
-                    elements = data.get("elements", [])
-                    if not elements:
-                        return Analytics(impressions=0, clicks=0, cost=0.0)
-
-                    total_impressions = sum(e.get("impressions", 0) for e in elements)
-                    total_clicks = sum(e.get("clicks", 0) for e in elements)
-                    total_cost = sum(float(e.get("costInLocalCurrency", 0) or 0) for e in elements)
-
-                    return Analytics(
-                        impressions=total_impressions,
-                        clicks=total_clicks,
-                        cost=total_cost,
-                    )
-                else:
-                    logger.error(f"Failed to get analytics: {response.status_code} - {response.text}")
-                    self.problems.append(f"Failed to get analytics: {response.status_code}")
-                    return None
-        except Exception as e:
-            logger.exception("Exception fetching analytics")
-            self.problems.append(f"Exception fetching analytics: {e}")
-            return None
+            if method_id == "linkedin.auth.userinfo.get.v1":
+                return await self._request(method_id, "GET", "/v2/userinfo")
+            if method_id == "linkedin.assets.register_image_upload.v1":
+                return await self._request(
+                    method_id,
+                    "POST",
+                    "/v2/assets?action=registerUpload",
+                    body=self._build_register_upload_payload(args, "image"),
+                )
+            if method_id == "linkedin.assets.register_video_upload.v1":
+                return await self._request(
+                    method_id,
+                    "POST",
+                    "/v2/assets?action=registerUpload",
+                    body=self._build_register_upload_payload(args, "video"),
+                )
+            if method_id == "linkedin.posts.create_text.v1":
+                return await self._request(
+                    method_id,
+                    "POST",
+                    "/v2/ugcPosts",
+                    body=self._build_share_payload(args, "NONE"),
+                )
+            if method_id == "linkedin.posts.create_article.v1":
+                return await self._request(
+                    method_id,
+                    "POST",
+                    "/v2/ugcPosts",
+                    body=self._build_share_payload(args, "ARTICLE"),
+                )
+            if method_id == "linkedin.posts.create_image.v1":
+                return await self._request(
+                    method_id,
+                    "POST",
+                    "/v2/ugcPosts",
+                    body=self._build_share_payload(args, "IMAGE"),
+                )
+            if method_id == "linkedin.posts.create_video.v1":
+                return await self._request(
+                    method_id,
+                    "POST",
+                    "/v2/ugcPosts",
+                    body=self._build_share_payload(args, "VIDEO"),
+                )
+        except ValueError as e:
+            return self._invalid_args(method_id, str(e))
+        return json.dumps({"ok": False, "error_code": "METHOD_UNIMPLEMENTED", "method_id": method_id}, indent=2, ensure_ascii=False)

--- a/flexus_client_kit/integrations/fi_linkedin_b2b.py
+++ b/flexus_client_kit/integrations/fi_linkedin_b2b.py
@@ -1,0 +1,1175 @@
+import json
+import logging
+from typing import Any, Dict, Optional
+from urllib.parse import quote
+
+import httpx
+
+from flexus_client_kit import ckit_cloudtool
+
+
+logger = logging.getLogger("linkedin_b2b")
+
+PROVIDER_NAME = "linkedin_b2b"
+METHOD_IDS = [
+    "linkedin_b2b.organizations.get.v1",
+    "linkedin_b2b.organizations.search.v1",
+    "linkedin_b2b.organization_acls.member_organizations.list.v1",
+    "linkedin_b2b.organization_acls.organization_members.list.v1",
+    "linkedin_b2b.organization_posts.create.v1",
+    "linkedin_b2b.organization_posts.get.v1",
+    "linkedin_b2b.organization_posts.list.v1",
+    "linkedin_b2b.organization_posts.delete.v1",
+    "linkedin_b2b.comments.create.v1",
+    "linkedin_b2b.comments.get.v1",
+    "linkedin_b2b.comments.list.v1",
+    "linkedin_b2b.comments.update.v1",
+    "linkedin_b2b.comments.delete.v1",
+    "linkedin_b2b.reactions.create.v1",
+    "linkedin_b2b.reactions.list.v1",
+    "linkedin_b2b.reactions.delete.v1",
+    "linkedin_b2b.social_metadata.get.v1",
+    "linkedin_b2b.followers.get.v1",
+    "linkedin_b2b.followers.stats.get.v1",
+    "linkedin_b2b.page_analytics.get.v1",
+    "linkedin_b2b.share_statistics.get.v1",
+    "linkedin_b2b.video_analytics.get.v1",
+    "linkedin_b2b.member_profile_analytics.get.v1",
+    "linkedin_b2b.member_post_analytics.get.v1",
+    "linkedin_b2b.mentions.people.search.v1",
+    "linkedin_b2b.notifications.social_actions.list.v1",
+    "linkedin_b2b.ad_accounts.get.v1",
+    "linkedin_b2b.ad_accounts.list.v1",
+    "linkedin_b2b.ad_account_users.get.v1",
+    "linkedin_b2b.ad_account_users.list.v1",
+    "linkedin_b2b.ad_account_users.create.v1",
+    "linkedin_b2b.ad_account_users.update.v1",
+    "linkedin_b2b.ad_account_users.delete.v1",
+    "linkedin_b2b.ad_campaign_groups.create.v1",
+    "linkedin_b2b.ad_campaign_groups.get.v1",
+    "linkedin_b2b.ad_campaign_groups.list.v1",
+    "linkedin_b2b.ad_campaign_groups.update.v1",
+    "linkedin_b2b.ad_campaigns.create.v1",
+    "linkedin_b2b.ad_campaigns.get.v1",
+    "linkedin_b2b.ad_campaigns.list.v1",
+    "linkedin_b2b.ad_campaigns.update.v1",
+    "linkedin_b2b.creatives.create.v1",
+    "linkedin_b2b.creatives.get.v1",
+    "linkedin_b2b.creatives.list.v1",
+    "linkedin_b2b.ad_analytics.get.v1",
+    "linkedin_b2b.ad_analytics.query.v1",
+    "linkedin_b2b.audience_counts.get.v1",
+    "linkedin_b2b.targeting_facets.list.v1",
+    "linkedin_b2b.targeting_entities.list.v1",
+    "linkedin_b2b.lead_forms.get.v1",
+    "linkedin_b2b.lead_forms.list.v1",
+    "linkedin_b2b.lead_forms.create.v1",
+    "linkedin_b2b.lead_forms.update.v1",
+    "linkedin_b2b.events.create.v1",
+    "linkedin_b2b.events.get.v1",
+    "linkedin_b2b.events.update.v1",
+    "linkedin_b2b.events.list_by_organizer.v1",
+    "linkedin_b2b.events.list_leadgen_by_organizer.v1",
+    "linkedin_b2b.events.register_background_upload.v1",
+    "linkedin_b2b.lead_sync.forms.get.v1",
+    "linkedin_b2b.lead_sync.forms.list.v1",
+    "linkedin_b2b.lead_sync.responses.get.v1",
+    "linkedin_b2b.lead_sync.responses.list.v1",
+    "linkedin_b2b.lead_sync.notifications.create.v1",
+    "linkedin_b2b.lead_sync.notifications.get.v1",
+    "linkedin_b2b.lead_sync.notifications.delete.v1",
+    "linkedin_b2b.conversions.create.v1",
+    "linkedin_b2b.conversions.get.v1",
+    "linkedin_b2b.conversions.list.v1",
+    "linkedin_b2b.conversions.associate_campaigns.v1",
+    "linkedin_b2b.conversion_events.upload.v1",
+    "linkedin_b2b.dmp_segments.create.v1",
+    "linkedin_b2b.dmp_segments.get.v1",
+    "linkedin_b2b.dmp_segments.list.v1",
+    "linkedin_b2b.dmp_segments.update.v1",
+    "linkedin_b2b.dmp_segment_users.upload.v1",
+    "linkedin_b2b.dmp_segment_companies.upload.v1",
+    "linkedin_b2b.dmp_segment_destinations.list.v1",
+    "linkedin_b2b.dmp_segment_list_uploads.get.v1",
+    "linkedin_b2b.ad_segments.list.v1",
+    "linkedin_b2b.website_retargeting.list.v1",
+    "linkedin_b2b.predictive_audiences.list.v1",
+    "linkedin_b2b.audience_insights.query.v1",
+    "linkedin_b2b.media_planning.forecast_reach.v1",
+    "linkedin_b2b.media_planning.forecast_impressions.v1",
+    "linkedin_b2b.media_planning.forecast_leads.v1",
+    "linkedin_b2b.account_intelligence.get.v1",
+]
+
+_BASE_URL = "https://api.linkedin.com"
+_TIMEOUT = 30.0
+
+LINKEDIN_B2B_TOOL = ckit_cloudtool.CloudTool(
+    strict=False,
+    name="linkedin_b2b",
+    description="LinkedIn non-partner B2B APIs: Community Management, Ads, Leads, Events, Conversions, and qualified private marketing surfaces.",
+    parameters={
+        "type": "object",
+        "properties": {
+            "op": {"type": "string", "description": "Use help, status, list_methods, or call."},
+            "args": {"type": "object"},
+        },
+        "required": [],
+    },
+)
+
+# B2B LinkedIn shares the same OAuth provider as open LinkedIn: "linkedin".
+# App-level keys are not pasted into this module. They belong in the platform auth provider:
+# - client_id: LinkedIn app Client ID from developer.linkedin.com
+# - client_secret: LinkedIn app Client Secret from developer.linkedin.com
+# - redirect_uri: the Flexus OAuth callback URL configured in the platform auth layer
+# - scopes: the reviewed LinkedIn Marketing / Community / Lead Sync scopes approved for this app
+# After OAuth completes, Flexus must store token.access_token in rcx.external_auth["linkedin"].
+# The setup schema below is only for default runtime IDs that the bot can reuse on calls.
+LINKEDIN_B2B_SETUP_SCHEMA = [
+    {
+        "bs_name": "ad_account_id",
+        "bs_type": "string_short",
+        "bs_default": "",
+        "bs_group": "LinkedIn B2B",
+        "bs_order": 10,
+        "bs_importance": 1,
+        "bs_description": (
+            "Default LinkedIn Ads account ID used by ad and lead methods. "
+            "Value: the numeric ad account ID, for example 123456789. "
+            "Get it from LinkedIn Campaign Manager or from the adAccounts API after auth works. "
+            "Paste it into this setup field in the bot/persona setup, not into OAuth secrets."
+        ),
+    },
+    {
+        "bs_name": "organization_id",
+        "bs_type": "string_short",
+        "bs_default": "",
+        "bs_group": "LinkedIn B2B",
+        "bs_order": 20,
+        "bs_importance": 1,
+        "bs_description": (
+            "Default LinkedIn organization ID used by page, org, post, follower, and analytics methods. "
+            "Value: the numeric organization ID, for example 987654321. "
+            "Get it from the LinkedIn Page admin URL, organization lookup calls, or your onboarding data. "
+            "Paste it into this setup field in the bot/persona setup."
+        ),
+    },
+    {
+        "bs_name": "linkedin_api_version",
+        "bs_type": "string_short",
+        "bs_default": "202509",
+        "bs_group": "LinkedIn B2B",
+        "bs_order": 30,
+        "bs_importance": 1,
+        "bs_description": (
+            "LinkedIn Marketing API version header in YYYYMM format. "
+            "Value: a version string like 202509. "
+            "Get it from the LinkedIn Marketing API versioning docs and keep it aligned with the approved API surface. "
+            "Paste it into this setup field only if you need to override the default shipped version."
+        ),
+    },
+]
+
+
+class IntegrationLinkedinB2B:
+    def __init__(
+        self,
+        rcx=None,
+        ad_account_id: str = "",
+        organization_id: str = "",
+        linkedin_api_version: str = "202509",
+    ):
+        self.rcx = rcx
+        self.ad_account_id = str(ad_account_id or "").strip()
+        self.organization_id = str(organization_id or "").strip()
+        self.linkedin_api_version = str(linkedin_api_version or "202509").strip()
+
+    def _auth(self) -> Dict[str, Any]:
+        # Same auth storage contract as fi_linkedin.py:
+        # - provider name in Flexus auth layer: "linkedin"
+        # - connected account payload location: rcx.external_auth["linkedin"]
+        # - required value for runtime calls: token.access_token
+        # This module does not own client_id/client_secret storage; our responsibility starts once
+        # the platform auth layer already exposes the connected account here.
+        return (self.rcx.external_auth.get("linkedin") or {}) if self.rcx else {}
+
+    def _access_token(self) -> str:
+        auth = self._auth()
+        token_obj = auth.get("token") or {}
+        return str(token_obj.get("access_token", "") or auth.get("oauth_token", "")).strip()
+
+    def _status(self) -> str:
+        access_token = self._access_token()
+        return json.dumps({
+            "ok": bool(access_token),
+            "provider": PROVIDER_NAME,
+            "status": "ready" if access_token else "missing_credentials",
+            "method_count": len(METHOD_IDS),
+            "auth_provider": "linkedin",
+            "default_ad_account_id": self.ad_account_id,
+            "default_organization_id": self.organization_id,
+            "linkedin_api_version": self.linkedin_api_version,
+            "products": [
+                "Community Management API",
+                "Advertising API",
+                "Events Management API",
+                "Lead Sync API",
+                "Conversions API",
+                "Matched Audiences API",
+                "Audience Insights API",
+                "Media Planning API",
+                "Company Intelligence API",
+            ],
+            "has_access_token": bool(access_token),
+        }, indent=2, ensure_ascii=False)
+
+    def _help(self) -> str:
+        return (
+            f"provider={PROVIDER_NAME}\n"
+            "op=help | status | list_methods | call\n"
+            f"methods: {', '.join(METHOD_IDS)}\n"
+            "notes:\n"
+            "- This integration assumes official LinkedIn reviewed or qualified B2B access.\n"
+            "- Many create/update methods accept args.body for full pass-through provider payloads.\n"
+            "- Where LinkedIn docs expose only query-style resources, method ids normalize that shape into one call.\n"
+        )
+
+    def _headers(self, *, has_body: bool, restli_method: str = "") -> Dict[str, str]:
+        access_token = self._access_token()
+        headers = {
+            "Authorization": f"Bearer {access_token}",
+            "Linkedin-Version": self.linkedin_api_version,
+            "X-Restli-Protocol-Version": "2.0.0",
+        }
+        if has_body:
+            headers["Content-Type"] = "application/json"
+        if restli_method:
+            headers["X-RestLi-Method"] = restli_method
+        return headers
+
+    def _auth_missing(self, method_id: str) -> str:
+        return json.dumps({
+            "ok": False,
+            "provider": PROVIDER_NAME,
+            "method_id": method_id,
+            "error_code": "AUTH_MISSING",
+            "message": "Connect LinkedIn in workspace settings and ensure an access token is present.",
+        }, indent=2, ensure_ascii=False)
+
+    def _invalid_args(self, method_id: str, message: str) -> str:
+        return json.dumps({
+            "ok": False,
+            "provider": PROVIDER_NAME,
+            "method_id": method_id,
+            "error_code": "INVALID_ARGS",
+            "message": message,
+        }, indent=2, ensure_ascii=False)
+
+    def _docs_gap(self, method_id: str, message: str) -> str:
+        return json.dumps({
+            "ok": False,
+            "provider": PROVIDER_NAME,
+            "method_id": method_id,
+            "error_code": "OFFICIAL_DOCS_GAP",
+            "message": message,
+        }, indent=2, ensure_ascii=False)
+
+    def _result(self, method_id: str, result: Any) -> str:
+        return json.dumps({
+            "ok": True,
+            "provider": PROVIDER_NAME,
+            "method_id": method_id,
+            "result": result,
+        }, indent=2, ensure_ascii=False)
+
+    def _provider_error(self, method_id: str, status_code: int, body: str) -> str:
+        detail: Any = body[:500]
+        try:
+            detail = json.loads(body)
+        except json.JSONDecodeError:
+            pass
+        logger.info("linkedin_b2b api error method=%s status=%s body=%s", method_id, status_code, body[:300])
+        return json.dumps({
+            "ok": False,
+            "provider": PROVIDER_NAME,
+            "method_id": method_id,
+            "error_code": "PROVIDER_ERROR",
+            "http_status": status_code,
+            "detail": detail,
+        }, indent=2, ensure_ascii=False)
+
+    def _enc(self, value: Any) -> str:
+        return quote(str(value), safe="")
+
+    def _query(self, params: Dict[str, Any]) -> str:
+        parts = []
+        for key, value in params.items():
+            if value is None or value == "":
+                continue
+            if isinstance(value, bool):
+                value = "true" if value else "false"
+            parts.append(f"{key}={self._enc(value)}")
+        return "&".join(parts)
+
+    def _with_query(self, path: str, params: Dict[str, Any]) -> str:
+        query = self._query(params)
+        return f"{path}?{query}" if query else path
+
+    async def _request(
+        self,
+        method_id: str,
+        http_method: str,
+        path: str,
+        *,
+        body: Optional[Dict[str, Any]] = None,
+        restli_method: str = "",
+    ) -> str:
+        url = _BASE_URL + path
+        try:
+            async with httpx.AsyncClient(timeout=_TIMEOUT) as client:
+                if http_method == "GET":
+                    response = await client.get(url, headers=self._headers(has_body=False, restli_method=restli_method))
+                elif http_method == "POST":
+                    response = await client.post(url, headers=self._headers(has_body=True, restli_method=restli_method), json=body)
+                elif http_method == "PUT":
+                    response = await client.put(url, headers=self._headers(has_body=True, restli_method=restli_method), json=body)
+                elif http_method == "DELETE":
+                    response = await client.delete(url, headers=self._headers(has_body=False, restli_method=restli_method))
+                else:
+                    return json.dumps({"ok": False, "error_code": "UNSUPPORTED_HTTP_METHOD"}, indent=2, ensure_ascii=False)
+        except httpx.TimeoutException:
+            return json.dumps({"ok": False, "provider": PROVIDER_NAME, "method_id": method_id, "error_code": "TIMEOUT"}, indent=2, ensure_ascii=False)
+        except (httpx.HTTPError, ValueError) as e:
+            logger.error("linkedin_b2b request failed", exc_info=e)
+            return json.dumps({
+                "ok": False,
+                "provider": PROVIDER_NAME,
+                "method_id": method_id,
+                "error_code": "HTTP_ERROR",
+                "message": f"{type(e).__name__}: {e}",
+            }, indent=2, ensure_ascii=False)
+
+        if response.status_code >= 400:
+            return self._provider_error(method_id, response.status_code, response.text)
+
+        if response.status_code == 204 or not response.text.strip():
+            return self._result(method_id, {"status": "success"})
+        try:
+            payload: Any = response.json()
+        except json.JSONDecodeError:
+            payload = response.text
+        response_id = response.headers.get("x-restli-id") or response.headers.get("x-linkedin-id")
+        if response_id:
+            return self._result(method_id, {"id": response_id, "payload": payload})
+        return self._result(method_id, payload)
+
+    def _body(self, args: Dict[str, Any], required: bool = False) -> Dict[str, Any]:
+        body = args.get("body")
+        if isinstance(body, dict):
+            return body
+        if required:
+            raise ValueError("body is required and must be an object for this method.")
+        return {}
+
+    def _patch_body(self, args: Dict[str, Any]) -> Dict[str, Any]:
+        body = args.get("body")
+        if isinstance(body, dict):
+            return body
+        patch_set = args.get("set")
+        if isinstance(patch_set, dict) and patch_set:
+            return {"patch": {"$set": patch_set}}
+        raise ValueError("Provide body as a Rest.li patch object or set as a non-empty object.")
+
+    def _pick(self, args: Dict[str, Any], key: str, default: str = "") -> str:
+        return str(args.get(key, default)).strip()
+
+    def _organization_id(self, args: Dict[str, Any], required: bool = False) -> str:
+        value = self._pick(args, "organization_id", self.organization_id)
+        if required and not value:
+            raise ValueError("organization_id is required.")
+        return value
+
+    def _organization_urn(self, args: Dict[str, Any], required: bool = False) -> str:
+        if self._pick(args, "organization_urn"):
+            return self._pick(args, "organization_urn")
+        organization_id = self._organization_id(args, required=required)
+        return f"urn:li:organization:{organization_id}" if organization_id else ""
+
+    def _ad_account_id(self, args: Dict[str, Any], required: bool = False) -> str:
+        value = self._pick(args, "ad_account_id", self.ad_account_id)
+        if required and not value:
+            raise ValueError("ad_account_id is required.")
+        return value
+
+    def _ad_account_urn(self, args: Dict[str, Any], required: bool = False) -> str:
+        if self._pick(args, "ad_account_urn"):
+            return self._pick(args, "ad_account_urn")
+        ad_account_id = self._ad_account_id(args, required=required)
+        return f"urn:li:sponsoredAccount:{ad_account_id}" if ad_account_id else ""
+
+    def _campaign_urn(self, args: Dict[str, Any], required: bool = False) -> str:
+        if self._pick(args, "campaign_urn"):
+            return self._pick(args, "campaign_urn")
+        campaign_id = self._pick(args, "campaign_id")
+        if required and not campaign_id:
+            raise ValueError("campaign_id or campaign_urn is required.")
+        return f"urn:li:sponsoredCampaign:{campaign_id}" if campaign_id else ""
+
+    def _person_urn(self, args: Dict[str, Any], required: bool = False) -> str:
+        person_urn = self._pick(args, "person_urn") or self._pick(args, "role_assignee") or self._pick(args, "user_urn")
+        if required and not person_urn:
+            raise ValueError("person_urn is required.")
+        return person_urn
+
+    def _social_target_urn(self, args: Dict[str, Any], required: bool = False) -> str:
+        target_urn = self._pick(args, "target_urn") or self._pick(args, "entity_urn") or self._pick(args, "post_urn")
+        if required and not target_urn:
+            raise ValueError("target_urn is required.")
+        return target_urn
+
+    def _comment_id(self, args: Dict[str, Any], required: bool = False) -> str:
+        comment_id = self._pick(args, "comment_id")
+        if required and not comment_id:
+            raise ValueError("comment_id is required.")
+        return comment_id
+
+    async def called_by_model(
+        self,
+        toolcall: ckit_cloudtool.FCloudtoolCall,
+        model_produced_args: Optional[Dict[str, Any]],
+    ) -> str:
+        args = model_produced_args or {}
+        op = str(args.get("op", "help")).strip()
+        if op == "help":
+            return self._help()
+        if op == "status":
+            return self._status()
+        if op == "list_methods":
+            return json.dumps({"ok": True, "provider": PROVIDER_NAME, "method_ids": METHOD_IDS}, indent=2, ensure_ascii=False)
+        if op != "call":
+            return "Error: unknown op. Use help/status/list_methods/call."
+
+        call_args = args.get("args") or {}
+        method_id = str(call_args.get("method_id", "")).strip()
+        if not method_id:
+            return "Error: args.method_id required for op=call."
+        if method_id not in METHOD_IDS:
+            return json.dumps({"ok": False, "error_code": "METHOD_UNKNOWN", "method_id": method_id}, indent=2, ensure_ascii=False)
+        if not self._access_token():
+            return self._auth_missing(method_id)
+        return await self._dispatch(method_id, call_args)
+
+    async def _dispatch(self, method_id: str, args: Dict[str, Any]) -> str:  # noqa: C901
+        try:
+            if method_id == "linkedin_b2b.organizations.get.v1":
+                organization_id = self._organization_id(args, required=True)
+                return await self._request(method_id, "GET", f"/rest/organizations/{organization_id}")
+            if method_id == "linkedin_b2b.organizations.search.v1":
+                if self._pick(args, "vanity_name"):
+                    return await self._request(
+                        method_id,
+                        "GET",
+                        self._with_query("/rest/organizations", {"q": "vanityName", "vanityName": self._pick(args, "vanity_name")}),
+                    )
+                if isinstance(args.get("ids"), list) and args.get("ids"):
+                    ids = ",".join(str(x) for x in args.get("ids", []))
+                    return await self._request(method_id, "GET", self._with_query("/rest/organizationsLookup", {"ids": f"List({ids})"}))
+                raise ValueError("Provide vanity_name or ids for organization lookup.")
+            if method_id == "linkedin_b2b.organization_acls.member_organizations.list.v1":
+                person_urn = self._person_urn(args, required=True)
+                return await self._request(
+                    method_id,
+                    "GET",
+                    self._with_query("/rest/organizationAcls", {
+                        "q": "roleAssignee",
+                        "roleAssignee": person_urn,
+                        "start": self._pick(args, "start"),
+                        "count": self._pick(args, "count"),
+                        "state": self._pick(args, "state"),
+                        "role": self._pick(args, "role"),
+                    }),
+                )
+            if method_id == "linkedin_b2b.organization_acls.organization_members.list.v1":
+                organization_urn = self._organization_urn(args, required=True)
+                return await self._request(
+                    method_id,
+                    "GET",
+                    self._with_query("/rest/organizationAcls", {
+                        "q": "organization",
+                        "organization": organization_urn,
+                        "start": self._pick(args, "start"),
+                        "count": self._pick(args, "count"),
+                        "state": self._pick(args, "state"),
+                        "role": self._pick(args, "role"),
+                    }),
+                )
+            if method_id == "linkedin_b2b.organization_posts.create.v1":
+                return await self._request(method_id, "POST", "/rest/posts", body=self._body(args, required=True))
+            if method_id == "linkedin_b2b.organization_posts.get.v1":
+                post_urn = self._social_target_urn(args, required=True)
+                return await self._request(
+                    method_id,
+                    "GET",
+                    self._with_query(f"/rest/posts/{self._enc(post_urn)}", {"viewContext": self._pick(args, "viewContext")}),
+                )
+            if method_id == "linkedin_b2b.organization_posts.list.v1":
+                author = self._pick(args, "author") or self._organization_urn(args, required=True)
+                return await self._request(
+                    method_id,
+                    "GET",
+                    self._with_query("/rest/posts", {
+                        "q": "author",
+                        "author": author,
+                        "viewContext": self._pick(args, "viewContext"),
+                        "sortBy": self._pick(args, "sortBy"),
+                        "start": self._pick(args, "start"),
+                        "count": self._pick(args, "count"),
+                    }),
+                )
+            if method_id == "linkedin_b2b.organization_posts.delete.v1":
+                post_urn = self._social_target_urn(args, required=True)
+                return await self._request(method_id, "DELETE", f"/rest/posts/{self._enc(post_urn)}")
+            if method_id == "linkedin_b2b.comments.create.v1":
+                target_urn = self._social_target_urn(args, required=True)
+                return await self._request(method_id, "POST", f"/rest/socialActions/{self._enc(target_urn)}/comments", body=self._body(args, required=True))
+            if method_id == "linkedin_b2b.comments.get.v1":
+                target_urn = self._social_target_urn(args, required=True)
+                comment_id = self._comment_id(args, required=True)
+                return await self._request(method_id, "GET", f"/rest/socialActions/{self._enc(target_urn)}/comments/{comment_id}")
+            if method_id == "linkedin_b2b.comments.list.v1":
+                target_urn = self._social_target_urn(args, required=True)
+                return await self._request(
+                    method_id,
+                    "GET",
+                    self._with_query(f"/rest/socialActions/{self._enc(target_urn)}/comments", {
+                        "start": self._pick(args, "start"),
+                        "count": self._pick(args, "count"),
+                    }),
+                )
+            if method_id == "linkedin_b2b.comments.update.v1":
+                target_urn = self._social_target_urn(args, required=True)
+                comment_id = self._comment_id(args, required=True)
+                actor = self._pick(args, "actor")
+                if not actor:
+                    raise ValueError("actor is required for comment update.")
+                return await self._request(
+                    method_id,
+                    "POST",
+                    self._with_query(f"/rest/socialActions/{self._enc(target_urn)}/comments/{comment_id}", {"actor": actor}),
+                    body=self._body(args, required=True),
+                )
+            if method_id == "linkedin_b2b.comments.delete.v1":
+                target_urn = self._social_target_urn(args, required=True)
+                comment_id = self._comment_id(args, required=True)
+                actor = self._pick(args, "actor")
+                if not actor:
+                    raise ValueError("actor is required for comment delete.")
+                return await self._request(
+                    method_id,
+                    "DELETE",
+                    self._with_query(f"/rest/socialActions/{self._enc(target_urn)}/comments/{comment_id}", {"actor": actor}),
+                )
+            if method_id == "linkedin_b2b.reactions.create.v1":
+                actor = self._pick(args, "actor")
+                if not actor:
+                    raise ValueError("actor is required for reaction create.")
+                return await self._request(
+                    method_id,
+                    "POST",
+                    self._with_query("/rest/reactions", {"actor": actor}),
+                    body=self._body(args, required=True),
+                )
+            if method_id == "linkedin_b2b.reactions.list.v1":
+                entity_urn = self._social_target_urn(args, required=True)
+                return await self._request(
+                    method_id,
+                    "GET",
+                    self._with_query(f"/rest/reactions/(entity:{self._enc(entity_urn)})", {
+                        "q": "entity",
+                        "sort": self._pick(args, "sort"),
+                        "start": self._pick(args, "start"),
+                        "count": self._pick(args, "count"),
+                    }),
+                )
+            if method_id == "linkedin_b2b.reactions.delete.v1":
+                actor = self._pick(args, "actor")
+                entity_urn = self._social_target_urn(args, required=True)
+                if not actor:
+                    raise ValueError("actor is required for reaction delete.")
+                return await self._request(method_id, "DELETE", f"/rest/reactions/(actor:{self._enc(actor)},entity:{self._enc(entity_urn)})")
+            if method_id == "linkedin_b2b.social_metadata.get.v1":
+                entity_urn = self._social_target_urn(args, required=True)
+                return await self._request(method_id, "GET", f"/rest/socialMetadata/{self._enc(entity_urn)}")
+            if method_id == "linkedin_b2b.followers.get.v1":
+                organization_urn = self._organization_urn(args, required=True)
+                return await self._request(
+                    method_id,
+                    "GET",
+                    self._with_query(f"/rest/networkSizes/{self._enc(organization_urn)}", {"edgeType": "COMPANY_FOLLOWED_BY_MEMBER"}),
+                )
+            if method_id == "linkedin_b2b.followers.stats.get.v1":
+                organization_urn = self._organization_urn(args, required=True)
+                return await self._request(
+                    method_id,
+                    "GET",
+                    self._with_query("/rest/organizationalEntityFollowerStatistics", {
+                        "q": "organizationalEntity",
+                        "organizationalEntity": organization_urn,
+                        "timeIntervals": self._pick(args, "timeIntervals"),
+                    }),
+                )
+            if method_id == "linkedin_b2b.page_analytics.get.v1":
+                brand_urn = self._pick(args, "brand_urn")
+                if brand_urn:
+                    return await self._request(
+                        method_id,
+                        "GET",
+                        self._with_query("/rest/brandPageStatistics", {"q": "brand", "brand": brand_urn, "timeIntervals": self._pick(args, "timeIntervals")}),
+                    )
+                organization_urn = self._organization_urn(args, required=True)
+                return await self._request(
+                    method_id,
+                    "GET",
+                    self._with_query("/rest/organizationPageStatistics", {
+                        "q": "organization",
+                        "organization": organization_urn,
+                        "timeIntervals": self._pick(args, "timeIntervals"),
+                    }),
+                )
+            if method_id == "linkedin_b2b.share_statistics.get.v1":
+                organization_urn = self._organization_urn(args, required=True)
+                return await self._request(
+                    method_id,
+                    "GET",
+                    self._with_query("/rest/organizationalEntityShareStatistics", {
+                        "q": "organizationalEntity",
+                        "organizationalEntity": organization_urn,
+                        "timeIntervals": self._pick(args, "timeIntervals"),
+                        "shares": self._pick(args, "shares"),
+                        "ugcPosts": self._pick(args, "ugcPosts"),
+                    }),
+                )
+            if method_id == "linkedin_b2b.video_analytics.get.v1":
+                entity_urn = self._social_target_urn(args, required=True)
+                return await self._request(
+                    method_id,
+                    "GET",
+                    self._with_query("/rest/videoAnalytics", {
+                        "q": "entity",
+                        "entity": entity_urn,
+                        "type": self._pick(args, "type", "VIDEO_VIEW"),
+                        "aggregation": self._pick(args, "aggregation"),
+                        "timeRange": self._pick(args, "timeRange"),
+                    }),
+                )
+            if method_id == "linkedin_b2b.member_profile_analytics.get.v1":
+                if self._pick(args, "dateRange"):
+                    return await self._request(
+                        method_id,
+                        "GET",
+                        self._with_query("/rest/memberFollowersCount", {"q": "dateRange", "dateRange": self._pick(args, "dateRange")}),
+                    )
+                return await self._request(method_id, "GET", self._with_query("/rest/memberFollowersCount", {"q": "me"}))
+            if method_id == "linkedin_b2b.member_post_analytics.get.v1":
+                if self._pick(args, "entity"):
+                    return await self._request(
+                        method_id,
+                        "GET",
+                        self._with_query("/rest/memberCreatorPostAnalytics", {
+                            "q": "entity",
+                            "entity": self._pick(args, "entity"),
+                            "queryType": self._pick(args, "queryType"),
+                            "aggregation": self._pick(args, "aggregation"),
+                            "dateRange": self._pick(args, "dateRange"),
+                        }),
+                    )
+                return await self._request(
+                    method_id,
+                    "GET",
+                    self._with_query("/rest/memberCreatorPostAnalytics", {
+                        "q": "me",
+                        "queryType": self._pick(args, "queryType"),
+                        "aggregation": self._pick(args, "aggregation"),
+                        "dateRange": self._pick(args, "dateRange"),
+                    }),
+                )
+            if method_id == "linkedin_b2b.mentions.people.search.v1":
+                organization_urn = self._organization_urn(args, required=True)
+                vanity_url = self._pick(args, "vanity_url")
+                if vanity_url:
+                    return await self._request(
+                        method_id,
+                        "GET",
+                        self._with_query("/rest/vanityUrl", {
+                            "q": "vanityUrlAsOrganization",
+                            "vanityUrl": vanity_url,
+                            "organization": organization_urn,
+                        }),
+                    )
+                keywords = self._pick(args, "keywords")
+                if not keywords:
+                    raise ValueError("keywords is required unless vanity_url is provided.")
+                return await self._request(
+                    method_id,
+                    "GET",
+                    self._with_query("/rest/peopleTypeahead", {
+                        "q": "organizationFollowers",
+                        "keywords": keywords,
+                        "organization": organization_urn,
+                    }),
+                )
+            if method_id == "linkedin_b2b.notifications.social_actions.list.v1":
+                organization_urn = self._organization_urn(args, required=True)
+                return await self._request(
+                    method_id,
+                    "GET",
+                    self._with_query("/rest/organizationalEntityNotifications", {
+                        "q": "criteria",
+                        "organizationalEntity": organization_urn,
+                        "actions": self._pick(args, "actions"),
+                        "sourcePost": self._pick(args, "sourcePost"),
+                        "timeRange.start": self._pick(args, "timeRange.start"),
+                        "timeRange.end": self._pick(args, "timeRange.end"),
+                    }),
+                )
+            if method_id == "linkedin_b2b.ad_accounts.get.v1":
+                ad_account_id = self._ad_account_id(args, required=True)
+                return await self._request(method_id, "GET", f"/rest/adAccounts/{ad_account_id}")
+            if method_id == "linkedin_b2b.ad_accounts.list.v1":
+                return await self._request(
+                    method_id,
+                    "GET",
+                    self._with_query("/rest/adAccounts", {
+                        "q": "search",
+                        "search": self._pick(args, "search"),
+                        "pageSize": self._pick(args, "pageSize"),
+                        "pageToken": self._pick(args, "pageToken"),
+                    }),
+                )
+            if method_id == "linkedin_b2b.ad_account_users.get.v1":
+                account_urn = self._ad_account_urn(args, required=True)
+                user_urn = self._person_urn(args, required=True)
+                return await self._request(method_id, "GET", f"/rest/adAccountUsers/(account:{self._enc(account_urn)},user:{self._enc(user_urn)})")
+            if method_id == "linkedin_b2b.ad_account_users.list.v1":
+                account_urn = self._ad_account_urn(args)
+                if account_urn:
+                    return await self._request(
+                        method_id,
+                        "GET",
+                        self._with_query("/rest/adAccountUsers", {"q": "accounts", "accounts": account_urn}),
+                    )
+                return await self._request(method_id, "GET", self._with_query("/rest/adAccountUsers", {"q": "authenticatedUser"}))
+            if method_id == "linkedin_b2b.ad_account_users.create.v1":
+                account_urn = self._ad_account_urn(args, required=True)
+                user_urn = self._person_urn(args, required=True)
+                body = self._body(args) or {"account": account_urn, "user": user_urn, "role": self._pick(args, "role")}
+                if not body.get("role"):
+                    raise ValueError("role is required for ad account user create.")
+                return await self._request(method_id, "PUT", f"/rest/adAccountUsers/(account:{self._enc(account_urn)},user:{self._enc(user_urn)})", body=body)
+            if method_id == "linkedin_b2b.ad_account_users.update.v1":
+                account_urn = self._ad_account_urn(args, required=True)
+                user_urn = self._person_urn(args, required=True)
+                return await self._request(
+                    method_id,
+                    "POST",
+                    f"/rest/adAccountUsers/(account:{self._enc(account_urn)},user:{self._enc(user_urn)})",
+                    body=self._patch_body(args),
+                    restli_method="PARTIAL_UPDATE",
+                )
+            if method_id == "linkedin_b2b.ad_account_users.delete.v1":
+                account_urn = self._ad_account_urn(args, required=True)
+                user_urn = self._person_urn(args, required=True)
+                return await self._request(method_id, "DELETE", f"/rest/adAccountUsers/(account:{self._enc(account_urn)},user:{self._enc(user_urn)})")
+            if method_id == "linkedin_b2b.ad_campaign_groups.create.v1":
+                ad_account_id = self._ad_account_id(args, required=True)
+                return await self._request(method_id, "POST", f"/rest/adAccounts/{ad_account_id}/adCampaignGroups", body=self._body(args, required=True))
+            if method_id == "linkedin_b2b.ad_campaign_groups.get.v1":
+                ad_account_id = self._ad_account_id(args, required=True)
+                campaign_group_id = self._pick(args, "campaign_group_id")
+                if not campaign_group_id:
+                    raise ValueError("campaign_group_id is required.")
+                return await self._request(method_id, "GET", f"/rest/adAccounts/{ad_account_id}/adCampaignGroups/{campaign_group_id}")
+            if method_id == "linkedin_b2b.ad_campaign_groups.list.v1":
+                ad_account_id = self._ad_account_id(args, required=True)
+                return await self._request(
+                    method_id,
+                    "GET",
+                    self._with_query(f"/rest/adAccounts/{ad_account_id}/adCampaignGroups", {
+                        "q": "search",
+                        "search": self._pick(args, "search"),
+                        "pageSize": self._pick(args, "pageSize"),
+                        "pageToken": self._pick(args, "pageToken"),
+                    }),
+                )
+            if method_id == "linkedin_b2b.ad_campaign_groups.update.v1":
+                ad_account_id = self._ad_account_id(args, required=True)
+                campaign_group_id = self._pick(args, "campaign_group_id")
+                if not campaign_group_id:
+                    raise ValueError("campaign_group_id is required.")
+                return await self._request(
+                    method_id,
+                    "POST",
+                    f"/rest/adAccounts/{ad_account_id}/adCampaignGroups/{campaign_group_id}",
+                    body=self._patch_body(args),
+                    restli_method="PARTIAL_UPDATE",
+                )
+            if method_id == "linkedin_b2b.ad_campaigns.create.v1":
+                ad_account_id = self._ad_account_id(args, required=True)
+                return await self._request(method_id, "POST", f"/rest/adAccounts/{ad_account_id}/adCampaigns", body=self._body(args, required=True))
+            if method_id == "linkedin_b2b.ad_campaigns.get.v1":
+                ad_account_id = self._ad_account_id(args, required=True)
+                campaign_id = self._pick(args, "campaign_id")
+                if not campaign_id:
+                    raise ValueError("campaign_id is required.")
+                return await self._request(method_id, "GET", f"/rest/adAccounts/{ad_account_id}/adCampaigns/{campaign_id}")
+            if method_id == "linkedin_b2b.ad_campaigns.list.v1":
+                ad_account_id = self._ad_account_id(args, required=True)
+                return await self._request(
+                    method_id,
+                    "GET",
+                    self._with_query(f"/rest/adAccounts/{ad_account_id}/adCampaigns", {
+                        "q": "search",
+                        "search": self._pick(args, "search"),
+                        "pageSize": self._pick(args, "pageSize"),
+                        "pageToken": self._pick(args, "pageToken"),
+                    }),
+                )
+            if method_id == "linkedin_b2b.ad_campaigns.update.v1":
+                ad_account_id = self._ad_account_id(args, required=True)
+                campaign_id = self._pick(args, "campaign_id")
+                if not campaign_id:
+                    raise ValueError("campaign_id is required.")
+                return await self._request(
+                    method_id,
+                    "POST",
+                    f"/rest/adAccounts/{ad_account_id}/adCampaigns/{campaign_id}",
+                    body=self._patch_body(args),
+                    restli_method="PARTIAL_UPDATE",
+                )
+            if method_id == "linkedin_b2b.creatives.create.v1":
+                ad_account_id = self._ad_account_id(args, required=True)
+                action = self._pick(args, "action")
+                path = f"/rest/adAccounts/{ad_account_id}/creatives?action={self._enc(action)}" if action else f"/rest/adAccounts/{ad_account_id}/creatives"
+                return await self._request(method_id, "POST", path, body=self._body(args, required=True))
+            if method_id == "linkedin_b2b.creatives.get.v1":
+                ad_account_id = self._ad_account_id(args, required=True)
+                creative_urn = self._pick(args, "creative_urn") or self._pick(args, "creative_id")
+                if not creative_urn:
+                    raise ValueError("creative_urn or creative_id is required.")
+                return await self._request(method_id, "GET", f"/rest/adAccounts/{ad_account_id}/creatives/{self._enc(creative_urn)}")
+            if method_id == "linkedin_b2b.creatives.list.v1":
+                ad_account_id = self._ad_account_id(args, required=True)
+                return await self._request(
+                    method_id,
+                    "GET",
+                    self._with_query(f"/rest/adAccounts/{ad_account_id}/creatives", {
+                        "q": "criteria",
+                        "campaigns": self._pick(args, "campaigns"),
+                        "contentReferences": self._pick(args, "contentReferences"),
+                        "creatives": self._pick(args, "creatives"),
+                        "intendedStatuses": self._pick(args, "intendedStatuses"),
+                        "isTestAccount": self._pick(args, "isTestAccount"),
+                        "leadgenCreativeCallToActionDestinations": self._pick(args, "leadgenCreativeCallToActionDestinations"),
+                        "pageSize": self._pick(args, "pageSize"),
+                        "pageToken": self._pick(args, "pageToken"),
+                    }),
+                )
+            if method_id in {"linkedin_b2b.ad_analytics.get.v1", "linkedin_b2b.ad_analytics.query.v1"}:
+                return await self._request(
+                    method_id,
+                    "GET",
+                    self._with_query("/rest/adAnalytics", {
+                        "q": self._pick(args, "q", "analytics"),
+                        "pivot": self._pick(args, "pivot"),
+                        "pivots": self._pick(args, "pivots"),
+                        "timeGranularity": self._pick(args, "timeGranularity"),
+                        "dateRange": self._pick(args, "dateRange"),
+                        "campaigns": self._pick(args, "campaigns"),
+                        "accounts": self._pick(args, "accounts"),
+                        "campaignGroups": self._pick(args, "campaignGroups"),
+                        "creatives": self._pick(args, "creatives"),
+                        "shares": self._pick(args, "shares"),
+                        "fields": self._pick(args, "fields"),
+                        "account": self._pick(args, "account"),
+                    }),
+                )
+            if method_id == "linkedin_b2b.audience_counts.get.v1":
+                targeting_criteria = self._pick(args, "targetingCriteria")
+                if not targeting_criteria:
+                    raise ValueError("targetingCriteria is required.")
+                return await self._request(
+                    method_id,
+                    "GET",
+                    self._with_query("/rest/audienceCounts", {"q": "targetingCriteriaV2", "targetingCriteria": targeting_criteria}),
+                )
+            if method_id == "linkedin_b2b.targeting_facets.list.v1":
+                return await self._request(method_id, "GET", "/rest/adTargetingFacets")
+            if method_id == "linkedin_b2b.targeting_entities.list.v1":
+                query_kind = self._pick(args, "query_kind", "adTargetingFacet")
+                params = {"q": query_kind}
+                if query_kind == "adTargetingFacet":
+                    params["facet"] = self._pick(args, "facet")
+                elif query_kind == "typeahead":
+                    params["facet"] = self._pick(args, "facet")
+                    params["query"] = self._pick(args, "query")
+                elif query_kind == "urns":
+                    params["urns"] = self._pick(args, "urns")
+                else:
+                    raise ValueError("query_kind must be adTargetingFacet, typeahead, or urns.")
+                params["locale"] = self._pick(args, "locale")
+                params["queryVersion"] = self._pick(args, "queryVersion")
+                return await self._request(method_id, "GET", self._with_query("/rest/adTargetingEntities", params))
+            if method_id == "linkedin_b2b.lead_forms.get.v1":
+                lead_form_id = self._pick(args, "lead_form_id")
+                if not lead_form_id:
+                    raise ValueError("lead_form_id is required.")
+                return await self._request(method_id, "GET", f"/rest/leadForms/{lead_form_id}")
+            if method_id == "linkedin_b2b.lead_forms.list.v1":
+                owner = self._pick(args, "owner") or self._ad_account_urn(args) or self._organization_urn(args)
+                if not owner:
+                    raise ValueError("owner or ad_account_id or organization_id is required.")
+                return await self._request(
+                    method_id,
+                    "GET",
+                    self._with_query("/rest/leadForms", {
+                        "q": "owner",
+                        "owner": owner,
+                        "start": self._pick(args, "start"),
+                        "count": self._pick(args, "count"),
+                    }),
+                )
+            if method_id == "linkedin_b2b.lead_forms.create.v1":
+                return await self._request(method_id, "POST", "/rest/leadForms", body=self._body(args, required=True))
+            if method_id == "linkedin_b2b.lead_forms.update.v1":
+                lead_form_id = self._pick(args, "lead_form_id")
+                if not lead_form_id:
+                    raise ValueError("lead_form_id is required.")
+                return await self._request(
+                    method_id,
+                    "POST",
+                    f"/rest/leadForms/{lead_form_id}",
+                    body=self._patch_body(args),
+                    restli_method="PARTIAL_UPDATE",
+                )
+            if method_id == "linkedin_b2b.events.create.v1":
+                return await self._request(method_id, "POST", "/rest/events", body=self._body(args, required=True))
+            if method_id == "linkedin_b2b.events.get.v1":
+                event_id = self._pick(args, "event_id")
+                if not event_id:
+                    raise ValueError("event_id is required.")
+                return await self._request(method_id, "GET", f"/rest/events/{event_id}")
+            if method_id == "linkedin_b2b.events.update.v1":
+                event_id = self._pick(args, "event_id")
+                if not event_id:
+                    raise ValueError("event_id is required.")
+                return await self._request(
+                    method_id,
+                    "POST",
+                    f"/rest/events/{event_id}",
+                    body=self._patch_body(args),
+                    restli_method="PARTIAL_UPDATE",
+                )
+            if method_id == "linkedin_b2b.events.list_by_organizer.v1":
+                organizer = self._pick(args, "organizer") or self._organization_urn(args)
+                if not organizer:
+                    raise ValueError("organizer or organization_id is required.")
+                return await self._request(
+                    method_id,
+                    "GET",
+                    self._with_query("/rest/events", {
+                        "q": "eventsByOrganizer",
+                        "organizer": organizer,
+                        "start": self._pick(args, "start"),
+                        "count": self._pick(args, "count"),
+                        "excludeCancelled": self._pick(args, "excludeCancelled"),
+                        "timeBasedFilter": self._pick(args, "timeBasedFilter"),
+                        "entryCriteria": self._pick(args, "entryCriteria"),
+                        "sortOrder": self._pick(args, "sortOrder"),
+                    }),
+                )
+            if method_id == "linkedin_b2b.events.list_leadgen_by_organizer.v1":
+                organizer = self._pick(args, "organizer") or self._organization_urn(args, required=True)
+                return await self._request(
+                    method_id,
+                    "GET",
+                    self._with_query("/rest/events", {
+                        "q": "organizerLeadGenFormEnabledEvents",
+                        "organizer": organizer,
+                        "start": self._pick(args, "start"),
+                        "count": self._pick(args, "count"),
+                    }),
+                )
+            if method_id == "linkedin_b2b.events.register_background_upload.v1":
+                return await self._request(method_id, "POST", "/rest/assets?action=registerUpload", body=self._body(args, required=True))
+            if method_id == "linkedin_b2b.lead_sync.forms.get.v1":
+                lead_form_id = self._pick(args, "lead_form_id")
+                if not lead_form_id:
+                    raise ValueError("lead_form_id is required.")
+                return await self._request(method_id, "GET", f"/rest/leadForms/{lead_form_id}")
+            if method_id == "linkedin_b2b.lead_sync.forms.list.v1":
+                owner = self._pick(args, "owner") or self._ad_account_urn(args) or self._organization_urn(args)
+                if not owner:
+                    raise ValueError("owner or ad_account_id or organization_id is required.")
+                return await self._request(method_id, "GET", self._with_query("/rest/leadForms", {"q": "owner", "owner": owner, "start": self._pick(args, "start"), "count": self._pick(args, "count")}))
+            if method_id == "linkedin_b2b.lead_sync.responses.get.v1":
+                lead_id = self._pick(args, "lead_id")
+                if not lead_id:
+                    raise ValueError("lead_id is required.")
+                return await self._request(method_id, "GET", f"/rest/leadFormResponses/{lead_id}")
+            if method_id == "linkedin_b2b.lead_sync.responses.list.v1":
+                owner = self._pick(args, "owner") or self._ad_account_urn(args) or self._organization_urn(args)
+                if not owner:
+                    raise ValueError("owner or ad_account_id or organization_id is required.")
+                lead_type = self._pick(args, "leadType")
+                if not lead_type:
+                    raise ValueError("leadType is required.")
+                return await self._request(
+                    method_id,
+                    "GET",
+                    self._with_query("/rest/leadFormResponses", {
+                        "q": "owner",
+                        "owner": owner,
+                        "leadType": f"(leadType:{lead_type})",
+                        "versionedLeadGenFormUrn": self._pick(args, "versionedLeadGenFormUrn"),
+                        "associatedEntity": self._pick(args, "associatedEntity"),
+                        "submittedAtTimeRange": self._pick(args, "submittedAtTimeRange"),
+                        "limitedToTestLeads": self._pick(args, "limitedToTestLeads"),
+                        "start": self._pick(args, "start"),
+                        "count": self._pick(args, "count"),
+                    }),
+                )
+            if method_id == "linkedin_b2b.lead_sync.notifications.create.v1":
+                return await self._request(method_id, "POST", "/rest/leadNotifications", body=self._body(args, required=True))
+            if method_id == "linkedin_b2b.lead_sync.notifications.get.v1":
+                notification_id = self._pick(args, "notification_id")
+                if not notification_id:
+                    raise ValueError("notification_id is required.")
+                return await self._request(method_id, "GET", f"/rest/leadNotifications/{notification_id}")
+            if method_id == "linkedin_b2b.lead_sync.notifications.delete.v1":
+                notification_id = self._pick(args, "notification_id")
+                if not notification_id:
+                    raise ValueError("notification_id is required.")
+                return await self._request(method_id, "DELETE", f"/rest/leadNotifications/{notification_id}")
+            if method_id == "linkedin_b2b.conversions.create.v1":
+                auto_association_type = self._pick(args, "autoAssociationType")
+                path = f"/rest/conversions?autoAssociationType={self._enc(auto_association_type)}" if auto_association_type else "/rest/conversions"
+                return await self._request(method_id, "POST", path, body=self._body(args, required=True))
+            if method_id == "linkedin_b2b.conversions.get.v1":
+                conversion_id = self._pick(args, "conversion_id")
+                if not conversion_id:
+                    raise ValueError("conversion_id is required.")
+                account = self._pick(args, "account") or self._ad_account_urn(args, required=True)
+                return await self._request(method_id, "GET", self._with_query(f"/rest/conversions/{conversion_id}", {"account": account}))
+            if method_id == "linkedin_b2b.conversions.list.v1":
+                account = self._pick(args, "account") or self._ad_account_urn(args, required=True)
+                return await self._request(method_id, "GET", self._with_query("/rest/conversions", {"q": "account", "account": account}))
+            if method_id == "linkedin_b2b.conversions.associate_campaigns.v1":
+                if isinstance(args.get("ids"), list) and args.get("ids"):
+                    ids = ",".join(str(x) for x in args.get("ids", []))
+                    body = self._body(args)
+                    return await self._request(
+                        method_id,
+                        "PUT",
+                        self._with_query("/rest/campaignConversions", {"ids": f"List({ids})"}),
+                        body=body,
+                        restli_method="BATCH_UPDATE",
+                    )
+                campaign_urn = self._campaign_urn(args, required=True)
+                conversion_urn = self._pick(args, "conversion_urn")
+                if not conversion_urn:
+                    raise ValueError("conversion_urn is required.")
+                return await self._request(
+                    method_id,
+                    "PUT",
+                    f"/rest/campaignConversions/(campaign:{self._enc(campaign_urn)},conversion:{self._enc(conversion_urn)})",
+                    body=self._body(args),
+                )
+            if method_id == "linkedin_b2b.conversion_events.upload.v1":
+                body = self._body(args, required=True)
+                restli_method = "BATCH_CREATE" if isinstance(body.get("elements"), list) else ""
+                return await self._request(method_id, "POST", "/rest/conversionEvents", body=body, restli_method=restli_method)
+            if method_id == "linkedin_b2b.dmp_segments.create.v1":
+                return await self._request(method_id, "POST", "/rest/dmpSegments", body=self._body(args, required=True))
+            if method_id == "linkedin_b2b.dmp_segments.get.v1":
+                dmp_segment_id = self._pick(args, "dmp_segment_id")
+                if not dmp_segment_id:
+                    raise ValueError("dmp_segment_id is required.")
+                return await self._request(method_id, "GET", f"/rest/dmpSegments/{dmp_segment_id}")
+            if method_id == "linkedin_b2b.dmp_segments.list.v1":
+                account = self._ad_account_urn(args, required=True)
+                return await self._request(method_id, "GET", self._with_query("/rest/dmpSegments", {"q": "account", "account": account}))
+            if method_id == "linkedin_b2b.dmp_segments.update.v1":
+                dmp_segment_id = self._pick(args, "dmp_segment_id")
+                if not dmp_segment_id:
+                    raise ValueError("dmp_segment_id is required.")
+                return await self._request(
+                    method_id,
+                    "POST",
+                    f"/rest/dmpSegments/{dmp_segment_id}",
+                    body=self._patch_body(args),
+                    restli_method="PARTIAL_UPDATE",
+                )
+            if method_id == "linkedin_b2b.dmp_segment_users.upload.v1":
+                dmp_segment_id = self._pick(args, "dmp_segment_id")
+                if not dmp_segment_id:
+                    raise ValueError("dmp_segment_id is required.")
+                body = self._body(args, required=True)
+                restli_method = "BATCH_CREATE" if isinstance(body.get("elements"), list) else ""
+                return await self._request(method_id, "POST", f"/rest/dmpSegments/{dmp_segment_id}/users", body=body, restli_method=restli_method)
+            if method_id == "linkedin_b2b.dmp_segment_companies.upload.v1":
+                dmp_segment_id = self._pick(args, "dmp_segment_id")
+                if not dmp_segment_id:
+                    raise ValueError("dmp_segment_id is required.")
+                body = self._body(args, required=True)
+                restli_method = "BATCH_CREATE" if isinstance(body.get("elements"), list) else ""
+                return await self._request(method_id, "POST", f"/rest/dmpSegments/{dmp_segment_id}/companies", body=body, restli_method=restli_method)
+            if method_id == "linkedin_b2b.dmp_segment_destinations.list.v1":
+                dmp_segment_id = self._pick(args, "dmp_segment_id")
+                if not dmp_segment_id:
+                    raise ValueError("dmp_segment_id is required.")
+                return await self._request(method_id, "GET", f"/rest/dmpSegments/{dmp_segment_id}/destinations")
+            if method_id == "linkedin_b2b.dmp_segment_list_uploads.get.v1":
+                dmp_segment_id = self._pick(args, "dmp_segment_id")
+                list_upload_id = self._pick(args, "list_upload_id")
+                if not dmp_segment_id or not list_upload_id:
+                    raise ValueError("dmp_segment_id and list_upload_id are required.")
+                return await self._request(method_id, "GET", f"/rest/dmpSegments/{dmp_segment_id}/listUploads/{list_upload_id}")
+            if method_id == "linkedin_b2b.ad_segments.list.v1":
+                account = self._ad_account_urn(args, required=True)
+                return await self._request(method_id, "GET", self._with_query("/rest/adSegments", {"q": "accounts", "accounts": f"List({account})", "start": self._pick(args, "start"), "count": self._pick(args, "count")}))
+            if method_id == "linkedin_b2b.website_retargeting.list.v1":
+                account = self._ad_account_urn(args, required=True)
+                return await self._request(method_id, "GET", self._with_query("/rest/adPageSets", {"q": "account", "account": account}))
+            if method_id == "linkedin_b2b.predictive_audiences.list.v1":
+                dmp_segment_id = self._pick(args, "dmp_segment_id")
+                predictive_audience_id = self._pick(args, "predictive_audience_id")
+                if not dmp_segment_id:
+                    raise ValueError("dmp_segment_id is required.")
+                if predictive_audience_id:
+                    return await self._request(method_id, "GET", f"/rest/dmpSegments/{dmp_segment_id}/businessObjectiveBasedAudiences/{predictive_audience_id}")
+                return self._docs_gap(method_id, "Official docs confirm get-by-id on businessObjectiveBasedAudiences. A collection list endpoint was not confidently documented.")
+            if method_id == "linkedin_b2b.audience_insights.query.v1":
+                return await self._request(method_id, "POST", "/rest/targetingAudienceInsights?action=audienceInsights", body=self._body(args, required=True))
+            if method_id == "linkedin_b2b.media_planning.forecast_reach.v1":
+                return await self._request(method_id, "POST", "/rest/mediaPlanning?action=forecastReaches", body=self._body(args, required=True))
+            if method_id == "linkedin_b2b.media_planning.forecast_impressions.v1":
+                return await self._request(method_id, "POST", "/rest/mediaPlanning?action=forecastImpressions", body=self._body(args, required=True))
+            if method_id == "linkedin_b2b.media_planning.forecast_leads.v1":
+                return await self._request(method_id, "POST", "/rest/mediaPlanning?action=forecastLeads", body=self._body(args, required=True))
+            if method_id == "linkedin_b2b.account_intelligence.get.v1":
+                account = self._pick(args, "account") or self._ad_account_urn(args, required=True)
+                return await self._request(
+                    method_id,
+                    "GET",
+                    self._with_query("/rest/accountIntelligence", {
+                        "q": "account",
+                        "account": account,
+                        "start": self._pick(args, "start"),
+                        "count": self._pick(args, "count"),
+                        "filterCriteria": self._pick(args, "filterCriteria"),
+                    }),
+                )
+        except ValueError as e:
+            return self._invalid_args(method_id, str(e))
+        return json.dumps({"ok": False, "error_code": "METHOD_UNIMPLEMENTED", "method_id": method_id}, indent=2, ensure_ascii=False)


### PR DESCRIPTION
## Summary

- **LinkedIn**: simplified init (`rcx` only), updated OAuth scopes to `openid/profile/email/w_member_social`
- **LinkedIn B2B**: new integration with full ads/org/social/events/leadgen API scopes
- **Generic handler**: `importlib`/`inspect`-based fallback in `ckit_integrations_db.py` — all future single-file `fi_*.py` integrations work without an explicit `elif`
- `main_loop_integrations_init`: relaxed `rcx` type, made `setup` optional

## Note for reviewer

This PR must be merged **before** any other `integration/*` PRs — those rely on the generic handler added here.