### PR TITLE
fix: tighten Karen BANT scoring and expand search scope

### DIFF
--- a/flexus_simple_bots/karen/karen_prompts.py
+++ b/flexus_simple_bots/karen/karen_prompts.py
@@ -151,7 +151,7 @@ You handle support (existing customers with questions) and sales (prospects expl
 ## Sales — C.L.O.S.E.R.
 
 Great sales feel like help, not pressure. Listen 70%, talk 30%. When in doubt, be honest and offer a human.
-Before quoting pricing, features, or setup details, call flexus_vector_search() to ground your answer in real data.
+Before quoting pricing, features, security/compliance, or setup details, call flexus_vector_search() to ground your answer in real data.
 
 - **Clarify**: ask why they're here — they must verbalize the problem, don't tell them what it is
 - **Label**: restate their problem in your own words, get agreement
@@ -168,8 +168,8 @@ Match energy: if positive and engaged, deepen and move toward close. If frustrat
 
 At the end of every sales conversation, score and store BANT in CRM using manage_crm_contact (contact_bant_score + contact_notes). If no contact yet, verify email first.
 
-- **Budget** (0/1): allocated or willing to invest?
-- **Authority** (0/1): decision-maker or strong influencer?
+- **Budget** (0/1): explicitly confirmed budget or got approval? ("workable" or "interesting" is not confirmation)
+- **Authority** (0/1): sole decision-maker? (if they need someone else's approval, score 0)
 - **Need** (0/1): urgent problem or just browsing?
 - **Timeline** (0/1): buying within 0-3 months?
 


### PR DESCRIPTION
## Summary
- Add security/compliance to pre-search scope (model must call `flexus_vector_search` before quoting)
- Tighten Budget: require explicit confirmation, not just "workable"/"interesting"
- Tighten Authority: require sole decision-maker, score 0 if needs approval

Note: The `fi_crm.py` field enumeration fix from the original branch is already in main.

## Context
5/25 scenario benchmarks flagged for fabrication — model skipped vector search before quoting pricing.

## Test plan
- [x] 25 Karen scenarios baselined at avg 6.0/10
- [ ] Re-run scenarios after merge to measure improvement

🤖 Generated with [Claude Code](https://claude.com/claude-code)