### PR TITLE
karen: clarify task resolution instructions in KAREN_KB

### DIFF
--- a/flexus_simple_bots/karen/karen_prompts.py
+++ b/flexus_simple_bots/karen/karen_prompts.py
@@ -46,12 +46,13 @@ process, search if available, compose answer, don't fabricate.
 
 ## Resolving Tasks
 
-Certainly DON'T resolve task immediately after giving an answer. Your answer might be wrong,
-or misunderstood, or insufficient.
+Don't resolve immediately after your first answer — wait for the user to confirm or say thanks.
 
-On inactivity timeout or user saying thank you => resolve the task.
-Look at your answers critically. Do they look good, then move task to success. Move task to failure if you
-see your answer is not good or made up, or you didn't have the information in the knowledge base.
+When the user signals they're done (says thank you, confirms they got what they needed, agrees to next step like a trial), resolve:
+  flexus_kanban_public(op="resolve", resolution={"code": "SUCCESS", "summary": "...", "uncapture": true})
+Then say TASK_COMPLETED.
+
+Use FAIL if your answers were fabricated or you couldn't find the information. Use INCONCLUSIVE if unclear.
 """
 
 


### PR DESCRIPTION
## Summary

- Replace vague "move task to success" with concrete `flexus_kanban_public(op="resolve", ...)` call format
- Add `uncapture: true` and `TASK_COMPLETED` — bot was leaving chats captured and not signaling completion
- Soften "DON'T resolve immediately" to "wait for user to confirm" — old wording made bot too cautious
- Add FAIL/INCONCLUSIVE guidance

Affects all Karen experts using KAREN_KB: default, very_limited, nurturing.

## Context

Scenario benchmarks showed Karen consistently fails to resolve kanban tasks at end of conversations (scored 7/10 instead of 10/10). Investigation found the resolution instruction exists in KAREN_KB but is too vague — bot doesn't know the exact tool call format needed.

## Test plan

- [ ] Run `very_limited__saas_cs_platform_short` scenario — verify bot calls `flexus_kanban_public(op="resolve")` and says `TASK_COMPLETED`
- [ ] Run `very_limited__actual_support` scenario — verify same
- [ ] Check that default and nurturing experts also resolve properly

🤖 Generated with [Claude Code](https://claude.com/claude-code)