### PR TITLE
feat: add persona-linked download links and configurable git authors

### DIFF
--- a/flexus_client_kit/integrations/fi_mongo_store.py
+++ b/flexus_client_kit/integrations/fi_mongo_store.py
@@ -142,6 +142,12 @@ async def handle_mongo_store(
         result_msg = f"Saved {path} -> MongoDB ({len(file_data)} bytes)"
         if was_overwritten:
             result_msg += " [OVERWRITTEN]"
+        persona_id = toolcall.connected_persona_id
+        if persona_id:
+            enc_path = urllib.parse.quote(path, safe="/")
+            enc_name = urllib.parse.quote(os.path.basename(path), safe="")
+            mime = _guess_mime_type(path)
+            result_msg += f"\n📎DOWNLOAD:{persona_id}:{enc_path}:{enc_name}:{mime}"
         return result_msg
 
     elif op == "upload":


### PR DESCRIPTION
- Support `connected_persona_id` in `python_executor.collect_artifacts` and `fi_mongo_store.save` to auto-generate `📎DOWNLOAD:` links for stored files
- Use repo config or custom params for git author in `botwiz_gitagent` commits and `devenv_pod_setup` clones (defaults to "Bob" / "bob@flexus.team")
- Update `flexus-bot-dev/SKILL.md` with expanded integrations tables, mongo_store/python_execute details, and full tool list