### PR TITLE
Adjust Discord DM and mention handling in IntegrationDiscord

### DIFF
--- a/flexus_client_kit/integrations/fi_discord2.py
+++ b/flexus_client_kit/integrations/fi_discord2.py
@@ -201,9 +201,7 @@ class IntegrationDiscord(fi_messenger.FlexusMessenger):
         logger.info("%s Discord %s by @%s in %s: %s", self.rcx.persona.persona_id, "message", a.message_author_name, a.channel_name, a.message_text[:50])
         if already_posted_to_captured_thread:
             return
-        # bot decides whether to respond -- group channels require @mention by default
-        if not a.bot_mentioned:
-            logger.info("%s Discord skip, not mentioned in group channel %s", self.rcx.persona.persona_id, a.channel_name)
+        if not a.is_dm and not a.bot_mentioned:
             return
         title = "Discord user=%r in %s\n%s" % (a.message_author_name, a.channel_name, a.message_text)
         if a.attachments:
@@ -728,7 +726,7 @@ class IntegrationDiscord(fi_messenger.FlexusMessenger):
             message_author_name=author_name,
             message_author_id=message.author.id,
             is_dm=is_dm,
-            bot_mentioned=is_dm or (self.client.user in message.mentions),
+            bot_mentioned=self.client.user in message.mentions,
             attachments=attachments,
         )
 


### PR DESCRIPTION
### Motivation
- Ensure direct messages are accepted for processing while keeping `bot_mentioned` strictly tied to explicit mentions and avoid silently treating DMs as mentions.

### Description
- Allow inbound activities to bypass the mention check for DMs by changing the gate to `if not a.is_dm and not a.bot_mentioned: return`.
- Stop auto-setting `bot_mentioned` for DMs by changing its construction to `bot_mentioned=self.client.user in message.mentions` and remove the previous `is_dm` fallback.
- Remove the informational log that previously noted skipped messages when not mentioned.

### Testing
- Ran the test suite with `pytest -q` and the unit tests covering Discord flows; all tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e64f76972c832fa8ecfdf34bc63164)