### PR TITLE
Inline DM channel check in Discord integration

### DIFF
--- a/flexus_client_kit/integrations/fi_discord2.py
+++ b/flexus_client_kit/integrations/fi_discord2.py
@@ -716,7 +716,6 @@ class IntegrationDiscord(fi_messenger.FlexusMessenger):
         text = message.content or ""
         attachments = await self._extract_attachments(message)
 
-        is_dm = isinstance(message.channel, discord.DMChannel)
         activity = ActivityDiscord(
             channel_name=await self._get_channel_name(channel_identifier),
             channel_id=channel_identifier,
@@ -725,7 +724,7 @@ class IntegrationDiscord(fi_messenger.FlexusMessenger):
             message_text=text,
             message_author_name=author_name,
             message_author_id=message.author.id,
-            is_dm=is_dm,
+            is_dm=isinstance(message.channel, discord.DMChannel),
             bot_mentioned=self.client.user in message.mentions,
             attachments=attachments,
         )


### PR DESCRIPTION
### Motivation
- Simplify the code by removing an unnecessary temporary variable and make the `ActivityDiscord` construction more concise.

### Description
- Replace the local assignment `is_dm = isinstance(message.channel, discord.DMChannel)` with an inline `is_dm=isinstance(message.channel, discord.DMChannel)` in the `ActivityDiscord` constructor, preserving behavior.

### Testing
- Ran the repository automated test suite and CI checks; all tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e6523611b4832f8290c35bd190f6fa)