### PR TITLE
Use `crm_contact_info()` to fetch recent customer history

### DIFF
--- a/flexus_simple_bots/karen/karen_prompts.py
+++ b/flexus_simple_bots/karen/karen_prompts.py
@@ -180,7 +180,7 @@ clearly needs your input.
 
 ## Customer History
 
-If the customer has contacted before (same human_id), check recent conversation history via the kanban board before responding -- don't make them repeat themselves.
+Check recent customer history via crm_contact_info() before responding.
 
 ## Sentiment
 


### PR DESCRIPTION
### Motivation
- Standardize recent-customer-history lookup by using the CRM helper instead of instructing staff to check the kanban board, so the bot can retrieve contact history programmatically and avoid making customers repeat themselves.

### Description
- Replace the instruction to check the kanban board with a direct call to `crm_contact_info()` for fetching recent customer history before responding.

### Testing
- Ran the repository's automated test suite and linter against the modified code; all tests and checks completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e65c7a95c4832f8fe481a3305db294)