### PR TITLE
feat: escalation enforcement — uncapture + 2h cooldown

### DIFF
--- a/flexus_client_kit/integrations/fi_discord2.py
+++ b/flexus_client_kit/integrations/fi_discord2.py
@@ -215,12 +215,8 @@ class IntegrationDiscord(fi_messenger.FlexusMessenger):
         if extra_details:
             details.update(extra_details)
         human_id = "discord:%d" % a.message_author_id if a.message_author_id else ""
-        if human_id:
-            now = time.time()
-            for task in self.rcx.latest_tasks.values():
-                if task.ktask_human_id == human_id and task.ktask_done_ts > 0 and now - task.ktask_done_ts < 7200:
-                    logger.info("%s skipping new task for %s — recently escalated (done_ts=%.0f)", self.rcx.persona.persona_id, human_id, task.ktask_done_ts)
-                    return
+        if self.is_task_recently_done(human_id):
+            return
         if not self.outside_messages_fexp_name:
             logger.warning("%s accept_outside_messages_only_to_expert() was never called, don't know which expert to use", self.rcx.persona.persona_id)
             return

--- a/flexus_client_kit/integrations/fi_discord2.py
+++ b/flexus_client_kit/integrations/fi_discord2.py
@@ -215,6 +215,12 @@ class IntegrationDiscord(fi_messenger.FlexusMessenger):
         if extra_details:
             details.update(extra_details)
         human_id = "discord:%d" % a.message_author_id if a.message_author_id else ""
+        if human_id:
+            now = time.time()
+            for task in self.rcx.latest_tasks.values():
+                if task.ktask_human_id == human_id and task.ktask_done_ts > 0 and now - task.ktask_done_ts < 7200:
+                    logger.info("%s skipping new task for %s — recently escalated (done_ts=%.0f)", self.rcx.persona.persona_id, human_id, task.ktask_done_ts)
+                    return
         if not self.outside_messages_fexp_name:
             logger.warning("%s accept_outside_messages_only_to_expert() was never called, don't know which expert to use", self.rcx.persona.persona_id)
             return

--- a/flexus_client_kit/integrations/fi_magic_desk.py
+++ b/flexus_client_kit/integrations/fi_magic_desk.py
@@ -68,6 +68,9 @@ class IntegrationMagicDesk(fi_messenger.FlexusMessenger):
     async def inbound_activity_to_task(self, a: ActivityMagicDesk, already_posted: bool):
         if already_posted:
             return
+        human_id = "magic_desk:%s" % a.session_id
+        if self.is_task_recently_done(human_id):
+            return
         if not self.outside_messages_fexp_name:
             logger.warning("%s accept_outside_messages_only_to_expert() was never called, don't know which expert to use", self.rcx.persona.persona_id)
             return

--- a/flexus_client_kit/integrations/fi_messenger.py
+++ b/flexus_client_kit/integrations/fi_messenger.py
@@ -1,7 +1,11 @@
+import logging
+import time
 from collections import deque
 from typing import List, Dict, Any
 
 from flexus_client_kit import ckit_ask_model, ckit_bot_exec, ckit_bot_query, ckit_client
+
+logger = logging.getLogger("messenger")
 
 MESSENGER_PROMPT = """
 ## Messaging Platforms (Telegram, Slack, WhatsApp, Flexus Magic Desk, etc.)
@@ -49,6 +53,22 @@ class FlexusMessenger:
 
     def accept_outside_messages_only_to_expert(self, fexp_name: str):
         self.outside_messages_fexp_name = fexp_name
+
+    def is_task_recently_done(self, human_id: str, max_age_s: float = 7200) -> bool:
+        """Check if the most recent task for human_id is done (resolved/escalated).
+
+        Prevents creating new tasks after human takeover. Uses in-memory latest_tasks
+        from the subscription — no GQL call needed.
+        """
+        if not human_id:
+            return False
+        now = time.time()
+        for task in self.rcx.latest_tasks.values():
+            if task.ktask_human_id == human_id and task.ktask_done_ts > 0 and now - task.ktask_done_ts < max_age_s:
+                logger.info("%s escalation guard: human_id=%s task %s is done (resolution=%s), skipping",
+                    self.rcx.persona.persona_id, human_id, task.ktask_id, task.ktask_resolution_code)
+                return True
+        return False
 
     async def handle_emessage(self, emsg: ckit_bot_query.FExternalMessageOutput) -> None:
         raise NotImplementedError

--- a/flexus_client_kit/integrations/fi_slack.py
+++ b/flexus_client_kit/integrations/fi_slack.py
@@ -207,6 +207,8 @@ class IntegrationSlack(fi_messenger.FlexusMessenger):
         if extra_details:
             details.update(extra_details)
         human_id = "slack:%s" % a.message_author_id if a.message_author_id else ""
+        if self.is_task_recently_done(human_id):
+            return
         if not self.outside_messages_fexp_name:
             logger.warning("%s accept_outside_messages_only_to_expert() was never called, don't know which expert to use", self.rcx.persona.persona_id)
             return

--- a/flexus_client_kit/integrations/fi_telegram.py
+++ b/flexus_client_kit/integrations/fi_telegram.py
@@ -2,7 +2,6 @@ import asyncio
 import re
 import json
 import logging
-import time
 import gql
 
 from collections import deque
@@ -388,11 +387,8 @@ class IntegrationTelegram(fi_messenger.FlexusMessenger):
             if a.attachments:
                 title += f"\n[{len(a.attachments)} file(s) attached]"
         human_id = "telegram:%d" % a.chat_id
-        now = time.time()
-        for task in self.rcx.latest_tasks.values():
-            if task.ktask_human_id == human_id and task.ktask_done_ts > 0 and now - task.ktask_done_ts < 7200:
-                logger.info("%s skipping new task for %s — recently escalated (done_ts=%.0f)", self.rcx.persona.persona_id, human_id, task.ktask_done_ts)
-                return
+        if self.is_task_recently_done(human_id):
+            return
         if not self.outside_messages_fexp_name:
             logger.warning("%s accept_outside_messages_only_to_expert() was never called, don't know which expert to use", self.rcx.persona.persona_id)
             return

--- a/flexus_client_kit/integrations/fi_telegram.py
+++ b/flexus_client_kit/integrations/fi_telegram.py
@@ -2,6 +2,7 @@ import asyncio
 import re
 import json
 import logging
+import time
 import gql
 
 from collections import deque
@@ -387,6 +388,11 @@ class IntegrationTelegram(fi_messenger.FlexusMessenger):
             if a.attachments:
                 title += f"\n[{len(a.attachments)} file(s) attached]"
         human_id = "telegram:%d" % a.chat_id
+        now = time.time()
+        for task in self.rcx.latest_tasks.values():
+            if task.ktask_human_id == human_id and task.ktask_done_ts > 0 and now - task.ktask_done_ts < 7200:
+                logger.info("%s skipping new task for %s — recently escalated (done_ts=%.0f)", self.rcx.persona.persona_id, human_id, task.ktask_done_ts)
+                return
         if not self.outside_messages_fexp_name:
             logger.warning("%s accept_outside_messages_only_to_expert() was never called, don't know which expert to use", self.rcx.persona.persona_id)
             return

--- a/flexus_simple_bots/karen/karen_prompts.py
+++ b/flexus_simple_bots/karen/karen_prompts.py
@@ -154,6 +154,7 @@ VERY_LIMITED = KAREN_PERSONALITY + "\n" + KAREN_KB + "\n" + """
 * Disclose your AI nature at the start of the conversation. Never pretend to be human.
 * Never give legal/medical/financial advice, guarantee outcomes, collect SSN/passwords, or use high-pressure tactics
 * Escalate to a human on: legal/fraud mentions, cancellation/refund requests, explicit requests for a human, or if frustration is obvious
+* When escalating: post your handoff message, then immediately call uncapture (telegram/discord op="uncapture"). Do NOT continue responding after escalation.
 
 You handle support (existing customers with questions) and sales (prospects exploring the product). Detect which from context.
 


### PR DESCRIPTION
## Summary

- Move the done-task check from duplicated inline code (Telegram, Discord) to a shared `is_task_recently_done()` method in `FlexusMessenger` base class
- Add the same check to Slack and Magic Desk integrations which were missing it
- When a human resolves/escalates a task, subsequent messages from the same contact no longer create new kanban tasks for 2 hours

## How it works

1. Customer triggers escalation → human resolves/escalates the kanban task
2. `ft_app_searchable` is cleared → subsequent messages no longer match `captured_thread_post_user_messages`
3. `inbound_activity_to_task` receives the next message with `already_posted=False`, but `is_task_recently_done()` finds the recently-done task and returns early
4. Human handles the conversation without bot interference
5. After 2h cooldown, new messages create tasks normally again

## Test plan

- [ ] Verify Telegram: resolve a task, send another message from same chat within 2h — no new task created
- [ ] Verify Slack: same pattern — resolve task, new message from same user skipped
- [ ] Verify Discord: same pattern
- [ ] Verify Magic Desk: same pattern
- [ ] Verify after 2h window, new messages DO create tasks again