### PR TITLE
eds: 24h auto-refresh for karen knowledge base

### DIFF
--- a/flexus_simple_bots/karen/skills/collect-support-knowledge-base/SKILL.md
+++ b/flexus_simple_bots/karen/skills/collect-support-knowledge-base/SKILL.md
@@ -32,8 +32,13 @@ flexus_vector_search() will be able to pages like "return policy" and answer que
 If you have a documentation website, that's perfect. Make EDS using flexus_eds_setup() for documentation to be
 indexed and then accessible using flexus_vector_search().
 
-ALWAYS set `rescan_period: 86400` (24 hours) in the EDS info when creating any EDS. This ensures the knowledge
-base stays fresh — the system automatically re-crawls/re-indexes every 24 hours.
+ALWAYS ask the user how often the knowledge base should refresh, proposing **24 hours** as the default. Most
+support content (FAQs, return policies, docs) changes slowly enough that daily is right; rapidly-changing
+sources (status pages, live inventory) may want shorter, and stable archives can go longer or one-time.
+
+Convert the user's answer to seconds and pass it as `rescan_period` in the EDS info when calling
+`flexus_eds_setup()` (e.g. `86400` = 24h, `3600` = 1h, `604800` = 7d, `0` = one-time only). If the user is
+unsure or doesn't care, use `86400`. The system then automatically re-crawls/re-indexes on that cadence.
 
 Set up MCP here in this chat. The newly created MCP tool will only be available after chat restart,
 so you will not be able to test MCP yourself, but you can send a subchat to check it.

--- a/flexus_simple_bots/karen/skills/collect-support-knowledge-base/SKILL.md
+++ b/flexus_simple_bots/karen/skills/collect-support-knowledge-base/SKILL.md
@@ -32,6 +32,9 @@ flexus_vector_search() will be able to pages like "return policy" and answer que
 If you have a documentation website, that's perfect. Make EDS using flexus_eds_setup() for documentation to be
 indexed and then accessible using flexus_vector_search().
 
+ALWAYS set `rescan_period: 86400` (24 hours) in the EDS info when creating any EDS. This ensures the knowledge
+base stays fresh — the system automatically re-crawls/re-indexes every 24 hours.
+
 Set up MCP here in this chat. The newly created MCP tool will only be available after chat restart,
 so you will not be able to test MCP yourself, but you can send a subchat to check it.
 


### PR DESCRIPTION
## Summary

- Add `rescan_period: 86400` instruction to Karen's collect-support-knowledge-base skill
- The auto-rescan infrastructure already exists in both crawler (`service_crawler.py:periodic_rescan_loop`) and unstructured (`service_unstructured.py:periodic_rescan_loop`) services
- Default is 604800 (7 days) — too slow for support KB. Karen needs 24h freshness.
- Zero backend changes needed — just telling Karen to set the config when creating EDS

## Karen plan item

Issue #26 (Fibery #2465) — EDS auto-refresh 24h

## Test plan

- [ ] Create a crawler EDS via Karen's KB collection skill
- [ ] Verify `eds_json.rescan_period` is 86400 on the created EDS
- [ ] Wait >24h or manually set `eds_last_scan_ts = 0` to trigger rescan
- [ ] Verify crawler re-indexes the source

🤖 Generated with [Claude Code](https://claude.com/claude-code)