### PR TITLE
feat(chat,devenv): add media_type to image uploads and setup params to scenarios

### DIFF
--- a/flexus_client_kit/ckit_bot_exec.py
+++ b/flexus_client_kit/ckit_bot_exec.py
@@ -1091,7 +1091,7 @@ async def run_bots_in_this_group(
         await scenario.create_group_and_hire_bot(
             marketable_name=marketable_name,
             marketable_version=marketable_version,
-            persona_setup={},
+            persona_setup=scenario.persona_setup,
         )
         try:
             async with (await scenario.fclient.use_http_on_behalf(None, "")) as http:

--- a/flexus_client_kit/ckit_scenario.py
+++ b/flexus_client_kit/ckit_scenario.py
@@ -37,6 +37,7 @@ def bot_launch_argparse():
     parser.add_argument("--no-cleanup", action="store_true", help="Skip cleanup of test group")
     parser.add_argument("--model", type=str, default="", help="Comma-separated list of models to run scenario against")
     parser.add_argument("--experiment", "-E", type=str, default="", help="Experiment name to append to output files")
+    parser.add_argument("--setup", action="append", default=[], metavar="KEY=VALUE", help="Set persona_setup key (repeatable), e.g. --setup TAVILY_API_KEY=tvly-abc123")
     return parser
 
 
@@ -243,6 +244,11 @@ class ScenarioSetup:
         self.should_cleanup = not args.no_cleanup
         self.explicit_models = [m.strip() for m in args.model.split(",") if m.strip()] if args.model else []
         self.experiment = args.experiment
+        self.persona_setup: dict = {}
+        for kv in (args.setup or []):
+            if "=" in kv:
+                k, v = kv.split("=", 1)
+                self.persona_setup[k] = v
 
     async def create_group_and_hire_bot(
         self,


### PR DESCRIPTION
- Enhance `chat_image_add` GraphQL mutation to return `ChatImageResult` with `url` and `media_type` (image/webp); update frontend upload hooks, cloudtool web screenshot, and hallucination adapters to handle it
- Add `setup` dict param (KEY=VALUE env vars for persona) to dev env scenario start via CLI (`--setup`), RPC, bob_test_bot `run_scenario`, and ckit tools; propagate via command flags and pass to bot hiring
- Support `/v1/chat-image/` URLs in JSON validator and resolve media URLs in adapters; minor fixes (remove log, strip data: imgs, polling tweak, labels)