### PR TITLE
fix: post_conversation human_id bug + prompt improvement

### DIFF
--- a/flexus_simple_bots/karen/karen_bot.py
+++ b/flexus_simple_bots/karen/karen_bot.py
@@ -591,6 +591,7 @@ async def karen_main_loop(fclient: ckit_client.FlexusClient, rcx: ckit_bot_exec.
                     }),
                     provenance_message="karen_post_conversation",
                     fexp_name="post_conversation",
+                    human_id=new_task.ktask_human_id,
                 )
 
     if telegram:

--- a/flexus_simple_bots/karen/karen_prompts.py
+++ b/flexus_simple_bots/karen/karen_prompts.py
@@ -240,13 +240,22 @@ KAREN_POST_CONVERSATION = """
 
 You run automatically after a customer conversation finishes. Update CRM and resolve.
 
-1. Use thread_read(ft_id=from_thread_id) to read the original conversation.
-2. Find the contact based on human_id in the task details:
-   - telegram:123456 → erp_table_data(table_name="crm_contact", options={"filters": "contact_platform_ids->telegram:=:123456"})
-   - email:user@example.com → erp_table_data(table_name="crm_contact", options={"filters": "contact_email:CIEQL:user@example.com"})
-3. No contact found? Create one with whatever info you can get from the conversation.
-4. Log the activity (fetch log-crm-activity skill).
-5. Resolve the task.
+0. Get task details: flexus_kanban_safe(op="status_safe") → note from_thread_id and human_id.
 
-Be fast. Don't overthink. Don't ask questions.
+1. Call ALL THREE in parallel:
+   - thread_read(ft_id=from_thread_id)
+   - Contact lookup by human_id:
+     telegram:123456 → erp_table_data(table_name="crm_contact", options={"filters": "contact_platform_ids->telegram:=:123456"})
+     email:user@example.com → erp_table_data(table_name="crm_contact", options={"filters": "contact_email:CIEQL:user@example.com"})
+   - flexus_fetch_skill(name="log-crm-activity")
+
+2. Process results:
+   - No contact? Create one with info from the conversation.
+   - Score BANT from conversation (Budget, Authority, Need, Timeline). Update contact fields.
+   - If a deal exists for this contact, update its stage based on conversation outcome.
+   - Log activity using the fetched skill template.
+
+3. Resolve: flexus_kanban_safe(op="resolve", resolution={"code": "DONE", "summary": "one-line what happened", "humanhours": 0, "uncapture": false})
+
+Be fast. Don't overthink. Don't ask questions. Batch tool calls when possible.
 """

--- a/flexus_simple_bots/karen/karen_prompts.py
+++ b/flexus_simple_bots/karen/karen_prompts.py
@@ -238,24 +238,36 @@ Match energy: if positive and engaged, deepen and move toward close. If frustrat
 KAREN_POST_CONVERSATION = """
 # Post-Conversation CRM Update
 
-You run automatically after a customer conversation finishes. Update CRM and resolve.
+You run automatically after a conversation ends. Complete in 4 rounds. No questions.
 
-0. Get task details: flexus_kanban_safe(op="status_safe") → note from_thread_id and human_id.
+## Round 1 — get task context
+flexus_kanban_safe(op="status_safe") → note from_thread_id and human_id from task details.
 
-1. Call ALL THREE in parallel:
-   - thread_read(ft_id=from_thread_id)
-   - Contact lookup by human_id:
-     telegram:123456 → erp_table_data(table_name="crm_contact", options={"filters": "contact_platform_ids->telegram:=:123456"})
-     email:user@example.com → erp_table_data(table_name="crm_contact", options={"filters": "contact_email:CIEQL:user@example.com"})
-   - flexus_fetch_skill(name="log-crm-activity")
+## Round 2 — read thread + find contact (call in parallel)
+- thread_read(ft_id=<from_thread_id>)
+- Contact lookup by human_id:
+  telegram:123456 → erp_table_data(table_name="crm_contact", options={"filters": "contact_platform_ids->telegram:=:123456"})
+  email:user@example.com → erp_table_data(table_name="crm_contact", options={"filters": "contact_email:CIEQL:user@example.com"})
+- No contact found? Create one with info from the conversation.
 
-2. Process results:
-   - No contact? Create one with info from the conversation.
-   - Score BANT from conversation (Budget, Authority, Need, Timeline). Update contact fields.
-   - If a deal exists for this contact, update its stage based on conversation outcome.
-   - Log activity using the fetched skill template.
+## Round 3 — log activity + BANT + deal (call in parallel)
+Log activity:
+  erp_table_crud(op="create", table_name="crm_activity", fields={
+    "activity_contact_id": "<id>", "activity_type": "MESSENGER_CHAT",
+    "activity_direction": "INBOUND", "activity_platform": "TELEGRAM",
+    "activity_title": "<short title>", "activity_summary": "<what happened>"
+  })
 
-3. Resolve: flexus_kanban_safe(op="resolve", resolution={"code": "DONE", "summary": "one-line what happened", "humanhours": 0, "uncapture": false})
+Score BANT from conversation and update contact:
+  erp_table_crud(op="patch", table_name="crm_contact", id="<id>", fields={
+    "contact_bant_score": 0-4,
+    "contact_details": {"bant": {"budget": 0|1, "budget_reason": "...", "authority": 0|1, "authority_reason": "...", "need": 0|1, "need_reason": "...", "timeline": 0|1, "timeline_reason": "..."}}
+  })
 
-Be fast. Don't overthink. Don't ask questions. Batch tool calls when possible.
+If a deal exists for this contact, update its stage based on outcome:
+  erp_table_data(table_name="crm_deal", options={"filters": "deal_contact_id:=:<contact_id>"})
+  erp_table_crud(op="patch", table_name="crm_deal", id="<id>", fields={"deal_stage_id": "<stage_id>", "deal_value": "...", "deal_closed_ts": ...})
+
+## Round 4 — resolve
+flexus_kanban_safe(op="resolve", resolution={"code": "SUCCESS", "summary": "<one-line what happened>", "humanhours": 0.1, "uncapture": false, "pdoc_paths": []})
 """

--- a/flexus_simple_bots/karen/post_conversation__bant_purchase.yaml
+++ b/flexus_simple_bots/karen/post_conversation__bant_purchase.yaml
@@ -1,5 +1,7 @@
 judge_instructions: No additional instructions
 
+fake_connected_providers: []
+
 messages:
   - role: cd_instruction
     content: |-

--- a/flexus_simple_bots/marco/marco_bot.py
+++ b/flexus_simple_bots/marco/marco_bot.py
@@ -126,6 +126,7 @@ async def marco_main_loop(fclient: ckit_client.FlexusClient, rcx: ckit_bot_exec.
                     }),
                     provenance_message="marco_post_conversation",
                     fexp_name="post_conversation",
+                    human_id=new_task.ktask_human_id,
                 )
 
     @telegram.on_incoming_activity


### PR DESCRIPTION
## Summary
- **Bug fix (#2426)**: `bot_kanban_post_into_inbox()` was called without `human_id=` param when spawning post_conversation tasks. The `ktask_human_id` column stayed empty, causing kanban safe scope to fail with "cannot determine human_id". Fixed in both `karen_bot.py` and `marco_bot.py`.
- **Prompt improvement (#2427)**: Restructured `KAREN_POST_CONVERSATION` from a terse 5-step list to explicit 4-round structure with parallel call hints. Inlined activity logging fields (saves a `flexus_fetch_skill` round). Added correct BANT scoring format and deal update instructions.
- **Scenario fix**: Added missing `fake_connected_providers: []` to `post_conversation__bant_purchase.yaml`.

## Changes
| File | Change |
|------|--------|
| `karen_bot.py` | +1 line: `human_id=new_task.ktask_human_id` |
| `marco_bot.py` | +1 line: same fix |
| `karen_prompts.py` | Rewrite `KAREN_POST_CONVERSATION` (36 lines replacing 20) |
| `post_conversation__bant_purchase.yaml` | +2 lines: `fake_connected_providers: []` |

## Test plan
- [ ] Run `post_conversation__bant_purchase` scenario on staging
- [ ] Verify kanban safe scope no longer errors on post_conversation tasks
- [ ] Verify model completes in ~4 tool call rounds instead of 8+

🤖 Generated with [Claude Code](https://claude.com/claude-code)