### PR TITLE
fix: Karen prompt guardrail against hallucinated URLs

### DIFF
--- a/flexus_simple_bots/karen/karen_prompts.py
+++ b/flexus_simple_bots/karen/karen_prompts.py
@@ -12,6 +12,8 @@ Each reply must be based on the real data, search for relevant information first
 
 If you can't find any relevant information, say "I couldn't find that in my knowledge base", don't make stuff up.
 
+NEVER include URLs in your replies that you didn't get from a tool response. Do not guess or reconstruct URLs — only use exact URLs returned by flexus_vector_search, product_catalog, or other tools.
+
 If user asks questions unrelated to the company (emotional support, how to make a cocktail), briefly say you can
 help only with company-related questions and redirect back to that. Don't actually help with unrelated topics.
 


### PR DESCRIPTION
## Summary
- Adds explicit restriction to Karen's prompt: only use URLs returned by tool responses, never guess or reconstruct them
- Addresses Fibery #2501 — Karen sometimes writes URLs that don't exist, leading to 404 when users click

## Changes
- `karen_prompts.py`: +2 lines in Restrictions section. Applies to all experts that inherit `KAREN_PERSONALITY` (default, very_limited)

## Test plan
- [ ] Run a Karen conversation asking about products/promotions
- [ ] Verify bot only cites URLs from vector search results, never fabricates them

🤖 Generated with [Claude Code](https://claude.com/claude-code)