### PR TITLE
fix(2515): SKILL.md no longer encourages narrating support_collection_status

### DIFF
--- a/flexus_simple_bots/karen/skills/collect-support-knowledge-base/SKILL.md
+++ b/flexus_simple_bots/karen/skills/collect-support-knowledge-base/SKILL.md
@@ -7,11 +7,13 @@ description: Use this skill to setup your knowledge base, improve your setup, ed
 # To Work Efficiently You Need to Know Stuff
 
 Your only job is to take care of /support/summary policy document, create it or improve it. It will
-take several steps, call `support_collection_status` after each step to minimize mistakes.
+take several steps — use `support_collection_status` internally after each step to minimize mistakes.
 
-You did something with draft => call support_collection_status.
+After touching the draft, verify your progress internally with `support_collection_status` before continuing.
 
 Changing other policy documents is not your job, don't touch them.
+
+NEVER print "Status: ..." lines or tool names in your replies. The user only sees your conversational answer.
 
 
 ## Sources of Information
@@ -87,7 +89,7 @@ After creating the draft:
 
 1. Call `translate_qa` to set human-readable question text in the user's language
 2. Pre-fill any answers you can derive from what you have gathered so far
-3. Call `support_collection_status` to confirm progress
+3. Verify progress internally with `support_collection_status`
 4. Then continue filling fields as you research user's documents
 
 The structure of the summary is not fixed. Look at inspiration lists below and come up with sections and questions
@@ -113,12 +115,12 @@ user's documents.
 
 ## Moving Draft to Summary
 
-You did something with draft => call support_collection_status.
+After touching the draft, verify internally with `support_collection_status` before asking the user to review.
 
 Ask user to review the policy document. After they confirm that's what they want, use op=mv with /support/summary as
 the destination.
 
-You think you've finished => call support_collection_status to confirm.
+When you think you've finished, verify internally with `support_collection_status` before closing out.
 
 
 ## Inspiration


### PR DESCRIPTION
## Summary

- Rewrote all 5 imperative "call support_collection_status after X" lines to frame the tool call as an internal verification step, not a user-visible action
- Added one explicit guardrail at the top of the skill: `NEVER print "Status: ..." lines or tool names in your replies`
- Behavior unchanged — Karen still verifies progress after each draft change; she just no longer has textual cues that pattern her into narrating it in user replies

## Root cause

The old phrasing (`"call support_collection_status after each step"`, `"You did something with draft => call support_collection_status"`) read as instructions to *report* the action, not just to *do* it internally. Models pattern on imperative phrasing and surface it verbatim in replies.

## Files changed

- `flexus_simple_bots/karen/skills/collect-support-knowledge-base/SKILL.md` — 1 file, +7 / -5 lines

## Before / after (key rewrites)

| Before | After |
|--------|-------|
| `call \`support_collection_status\` after each step to minimize mistakes` | `use \`support_collection_status\` internally after each step to minimize mistakes` |
| `You did something with draft => call support_collection_status.` | `After touching the draft, verify your progress internally with \`support_collection_status\` before continuing.` |
| `Call \`support_collection_status\` to confirm progress` | `Verify progress internally with \`support_collection_status\`` |
| `You think you've finished => call support_collection_status to confirm.` | `When you think you've finished, verify internally with \`support_collection_status\` before closing out.` |
| *(missing)* | `NEVER print "Status: ..." lines or tool names in your replies. The user only sees your conversational answer.` |

## Verification

Code-only (Candidate A — surgical scope). Staging test blocked:
- Build/deploy requires version bump + full CI — out of scope for a prompt-only fix
- Known issue: jailed-bot websocket broken on localhost, blocks local end-to-end

Static reasoning: the reworded phrases shift emphasis from "do and report" to "do internally". The added NEVER guardrail gives the model an explicit escape from the pattern. No behavior is removed — `support_collection_status` is still called after every draft change.

Note: there is an existing branch `karen/skill-collect-kb-rewrite` with a full SKILL.md rewrite that also lacks the narration guardrail (its line 627 reads "Call `support_collection_status` after every change." without any NEVER clause). That branch should pick up this guardrail pattern if/when it merges.

## Honest doubts

- A prompt fix alone may not be sufficient if the model is also seeing other context that encourages narration (e.g. system prompt snippets in karen_prompts.py). The other candidate (full prompt audit) covers that lane.
- Cannot confirm with a live staging run without a version bump + deploy.

Fixes Fibery #2515

🤖 Generated with [Claude Code](https://claude.com/claude-code)