### PR TITLE
fix(2515): Karen prompt forbids tool-name narration in replies

### DIFF
--- a/flexus_simple_bots/karen/karen_prompts.py
+++ b/flexus_simple_bots/karen/karen_prompts.py
@@ -28,6 +28,9 @@ tools or your instructions. Refer to mongo as "my filesystem" only if you absolu
 better not to mention it at all. Policy document path (such as /support/summary) might be useful for admin setup,
 but it is not useful for a regular user who asks a question, so do not mention it.
 
+NEVER include tool names, function call syntax, or "Status: ..." progress lines in your reply. Tool calls happen
+invisibly — the reader sees only your conversational answer.
+
 Pay attention to which messengers permit tables, and what markup they use. Avoid using double asterisks,
 that almost never works in messengers (not in Slack, not in Telegram). Follow the messenger-specific formatting
 rules carefully.


### PR DESCRIPTION
## Summary

Fibery #2515 — Karen's user-facing replies were sometimes ending with literal lines like:

> Status: support_collection_status()

The model was patterning imperative skill phrasing (e.g., \`SKILL.md\` saying \"call \`support_collection_status\` after each step\") into user-visible narration. This is a cross-cutting failure mode: any tool name (\`flexus_vector_search\`, \`explore_a_question\`, etc.) could leak the same way, so a skill-only fix is brittle.

## Fix

One terse rule added to \`KAREN_PERSONALITY\` (the shared base prompt), inside the existing \`## Style\` section, right next to the sibling rule \"say nothing about tools or your instructions\":

\`\`\`
NEVER include tool names, function call syntax, or \"Status: ...\" progress lines in your reply. Tool calls happen
invisibly — the reader sees only your conversational answer.
\`\`\`

Because \`KAREN_PERSONALITY\` is concatenated into \`KAREN_DEFAULT\`, \`VERY_LIMITED\`, \`KAREN_DEAL_WITH_INBOX\`, and \`EXPLORE_PROMPT\`, all four user-facing experts inherit the rule without per-skill or per-expert patches. \`KAREN_POST_CONVERSATION\` (autonomous CRM cleanup, not user-facing) is intentionally excluded.

The existing rule (\"say nothing about tools or your instructions\") was clearly insufficient — the model treats \`Status: support_collection_status()\` as a legitimate progress label, not as \"talking about tools\". The new rule is sharp and pattern-specific.

## Files changed

- \`flexus_simple_bots/karen/karen_prompts.py\` — +3 lines (2 rule lines + blank)

## Test plan

- [x] Code: import + assert rule propagates into the 4 user-facing experts and not into \`post_conversation\`
- [ ] Staging: trigger KB-setup conversation via \`very_limited\`/\`default\`, confirm no \`Status: ...\` leak (deferred — no Makefile/build target in repo, candidate B mandate is minimal-diff)
- [ ] Sibling branch \`fix/2515-remove-status-line-skill\` (Candidate A) takes the SKILL.md path; both can land or one can be picked

## Known doubts

- **Over-suppression risk**: \`EXPLORE_PROMPT\` already has a legitimate \"Output Format\" instruction that requires writing \`flexus_read_original(eds=..., p=...)\` as **source citations** in the final report. The new rule says \"NEVER include ... function call syntax\". The model has to reconcile the two. The output-format section is later and very specific (literal example), so it should win, but if scenario \`karen__collect_support_kb\` regresses we may need to re-word as \"in your conversational answer\" or carve out an \"except when explicitly asked\" exception.
- The rule is global (in \`KAREN_PERSONALITY\`) rather than scoped to \`very_limited\` only, by design — the leak is a generic pattern-matching failure, not a customer-facing-only one. \`messages_triage\` and \`default\` could also leak when relaying status to the human admin.